### PR TITLE
Upgrade to Play 2.3 and support Scala 2.10 and 2.11

### DIFF
--- a/playprovider/build.sbt
+++ b/playprovider/build.sbt
@@ -1,16 +1,19 @@
+name := fromEnv("project.artifactId").getOrElse("raygun4java-play2")
+
+organization := "com.mindscapehq"
+
+version := fromEnv("project.version").getOrElse("0.4.6-SNAPSHOT")
+
+scalaVersion := "2.11.4"
+
+crossScalaVersions := Seq("2.10.4", "2.11.1", "2.11.2", "2.11.4")
+
 libraryDependencies ++= Seq(
-  javaJdbc,
-  javaEbean,
-  cache,
-  "com.mindscapehq" % "core" % "1.3.1"
+  "com.mindscapehq" % "core" % "1.3.1",
+  "com.typesafe.play" %% "play" % play.core.PlayVersion.current
 )
 
 def fromEnv(name: String) = System.getenv(name) match {
     case null => None
     case value => Some(value)
 }
-
-val appName = fromEnv("project.artifactId").getOrElse("my-app")
-
-val appVersion = fromEnv("project.version").getOrElse("1.0-SNAPSHOT")
-

--- a/playprovider/project/build.properties
+++ b/playprovider/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/playprovider/project/plugins.sbt
+++ b/playprovider/project/plugins.sbt
@@ -2,4 +2,4 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.1")


### PR DESCRIPTION
The latest release of raygun4java-play2 isn't compatible with recent versions of the Play Framework. Version 0.4.5 is built against a snapshot release of Scala 2.9 and Play 2.3.x requires Scala 2.10 or higher. 

I couldn't get the dependencies upgraded in the Maven build, so I've only updated (and fixed) the SBT build. Cross Scala-version has been enabled, so running `sbt "+package"` will spit out jars for Scala 2.10 and Scala 2.11.