### PR TITLE
solve Crash Reporting Environment show issues #41

### DIFF
--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -149,7 +149,7 @@ public class RaygunClient {
 
                 HttpURLConnection connection = this.raygunConnection.getConnection(_apiKey);
 
-                OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
+                OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream(),"UTF8");
                 writer.write(jsonPayload);
                 writer.flush();
                 writer.close();


### PR DESCRIPTION
solve Crash Reporting Environment show issues #41

issues describe:Sometimes when the user operation system language is zh-CN,the Machine could not be showed correctly.

like this : Machine name	����-PC