### PR TITLE
Upgraded to Play 2.4

### DIFF
--- a/playprovider/project/build.properties
+++ b/playprovider/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.13

--- a/playprovider/project/plugins.sbt
+++ b/playprovider/project/plugins.sbt
@@ -2,4 +2,4 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.10")


### PR DESCRIPTION
Hey,

Since upgrading to Play 2.4, we're missing a lot of HTTP information. The cause of this is that play.api.mvc.Headers used to be a trait and has been changed to a class in 2.4.
This causes the following error in the Raygun Play client:
`"Couldn't get all request params: Found class play.api.mvc.Headers, but interface was expected"`

Upgrading to Play 2.4 fixes the issue.

Thanks!
Jan-Kees