### PR TITLE
Adds filtering to servlet request messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,16 @@ public RaygunMessage OnBeforeSend(RaygunMessage message) {
 }
 ```
 
+There are several provided classes for filtering, and use can use the `RaygunOnBeforeSendChain` to execute multiple `RaygunOnBeforeSend`
+```java
+raygunClient.SetOnBeforeSend(new RaygunOnBeforeSendChain()
+        .filterWith(new RaygunRequestQueryStringFilter("queryParam1", "queryParam2").replaceWith("*REDACTED*"))
+        .filterWith(new RaygunRequestHeaderFilter("header1", "header2"))
+        .filterWith(new RaygunRequestFormFilter("form1", "form2"))
+);
+```
+
+
 ### Custom error grouping
 
 You can override Raygun's default grouping logic for Java exceptions by setting the grouping key manually in OnBeforeSend (see above):

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
@@ -1,0 +1,46 @@
+package com.mindscapehq.raygun4java.core;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Chains multiple before-send handlers
+ * usage:
+ * raygunClient.SetOnBeforeSend(
+ *      new RaygunOnBeforeSendChain()
+ *          .filterWith(new RaygunRequestHeaderFilter("AUTH", "COOKIE"),
+ *          .filterWith(new RaygunRequestFormFilter("password", "secret")
+ *          ....
+ * );
+ */
+public class RaygunOnBeforeSendChain implements RaygunOnBeforeSend {
+
+    private List<RaygunOnBeforeSend> handlers;
+
+    public RaygunOnBeforeSendChain() {
+        this(new ArrayList<RaygunOnBeforeSend>());
+    }
+
+    public RaygunOnBeforeSendChain(List<RaygunOnBeforeSend> handlers) {
+        this.handlers = handlers;
+    }
+
+    public RaygunMessage OnBeforeSend(RaygunMessage message) {
+        for (RaygunOnBeforeSend raygunOnBeforeSend : getHandlers()) {
+            message = raygunOnBeforeSend.OnBeforeSend(message);
+        }
+
+        return message;
+    }
+
+    public List<RaygunOnBeforeSend> getHandlers() {
+        return handlers;
+    }
+
+    public RaygunOnBeforeSendChain filterWith(RaygunOnBeforeSend handler) {
+        handlers.add(handler);
+        return this;
+    }
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunRequestMessage.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunRequestMessage.java
@@ -81,4 +81,52 @@ public class RaygunRequestMessage {
         }
         return map;
     }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public Map<String, String> getForm() {
+        return form;
+    }
+
+    public Map<String, String> getData() {
+        return data;
+    }
+
+    public Map<String, String> getQueryString() {
+        return queryString;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/AbstractRaygunRequestMapFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/AbstractRaygunRequestMapFilter.java
@@ -1,0 +1,45 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunServletMessageDetails;
+
+import java.util.Map;
+
+/**
+ * Base class to filter/redact data from Raygun request maps
+ */
+public abstract class AbstractRaygunRequestMapFilter<T> implements RaygunOnBeforeSend {
+    private final String[] keysToFilter;
+    private String replacement = "[FILTERED]";
+
+    public AbstractRaygunRequestMapFilter(String... keysToFilter) {
+        this.keysToFilter = keysToFilter;
+    }
+
+    public abstract Map<String, String> GetMapToFilter(RaygunRequestMessage requestMessage);
+
+    protected void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
+
+    public RaygunMessage OnBeforeSend(RaygunMessage message) {
+
+        if (message.getDetails() != null && message.getDetails() instanceof RaygunServletMessageDetails) {
+            RaygunServletMessageDetails requestMessageDetails = (RaygunServletMessageDetails) message.getDetails();
+
+            if (requestMessageDetails.getRequest() != null) {
+                Map<String, String> mapToFilter = GetMapToFilter(requestMessageDetails.getRequest());
+
+                for (String key : keysToFilter) {
+                    if (mapToFilter.containsKey(key)) {
+                        mapToFilter.put(key, replacement);
+                    }
+                }
+            }
+        }
+
+        return message;
+    }
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunRequestFormFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunRequestFormFilter.java
@@ -1,0 +1,24 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+
+import java.util.Map;
+
+/**
+ * Given a list of form field names, this will replace the field values with an optional replacement
+ */
+public class RaygunRequestFormFilter extends AbstractRaygunRequestMapFilter {
+
+    public RaygunRequestFormFilter(String... keysToFilter) {
+        super(keysToFilter);
+    }
+
+    public Map<String, String> GetMapToFilter(RaygunRequestMessage requestMessage) {
+        return requestMessage.getForm();
+    }
+
+    public RaygunRequestFormFilter replaceWith(String replacement) {
+        setReplacement(replacement);
+        return this;
+    }
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunRequestHeaderFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunRequestHeaderFilter.java
@@ -1,0 +1,24 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+
+import java.util.Map;
+
+/**
+ * Given a list of header names, this will replace the header values with an optional replacement
+ */
+public class RaygunRequestHeaderFilter extends AbstractRaygunRequestMapFilter {
+
+    public RaygunRequestHeaderFilter(String... keysToFilter) {
+        super(keysToFilter);
+    }
+
+    public Map<String, String> GetMapToFilter(RaygunRequestMessage requestMessage) {
+        return requestMessage.getHeaders();
+    }
+
+    public RaygunRequestHeaderFilter replaceWith(String replacement) {
+        setReplacement(replacement);
+        return this;
+    }
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunRequestQueryStringFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunRequestQueryStringFilter.java
@@ -1,0 +1,24 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+
+import java.util.Map;
+
+/**
+ * Given a list of query string field names, this will replace the field values with an optional replacement
+ */
+public class RaygunRequestQueryStringFilter extends AbstractRaygunRequestMapFilter {
+
+    public RaygunRequestQueryStringFilter(String... keysToFilter) {
+        super(keysToFilter);
+    }
+
+    public Map<String, String> GetMapToFilter(RaygunRequestMessage requestMessage) {
+        return requestMessage.getQueryString();
+    }
+
+    public RaygunRequestQueryStringFilter replaceWith(String replacement) {
+        setReplacement(replacement);
+        return this;
+    }
+}

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
@@ -1,6 +1,11 @@
 package com.mindscapehq.raygun4java.webprovider;
 
+import com.mindscapehq.raygun4java.core.RaygunClient;
 import com.mindscapehq.raygun4java.core.RaygunConnection;
+import com.mindscapehq.raygun4java.core.RaygunOnBeforeSendChain;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestFormFilter;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestHeaderFilter;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestQueryStringFilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -10,12 +15,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,106 +29,159 @@ public class RaygunServletClientTest {
 
     private RaygunConnection raygunConnectionMock;
     private HttpServletRequest requestMock;
+    private ByteArrayOutputStream requestBody;
 
     @Before
-    public void setUp() {
-        this.requestMock = mock(HttpServletRequest.class);
-        this.raygunClient = new RaygunServletClient("1234", requestMock);
-        this.raygunConnectionMock = mock(RaygunConnection.class);
-        this.raygunClient.setRaygunConnection(raygunConnectionMock);
+    public void setUp() throws IOException {
+        requestMock = mock(HttpServletRequest.class);
+        raygunClient = new RaygunServletClient("1234", requestMock);
+        raygunConnectionMock = mock(RaygunConnection.class);
+        raygunClient.setRaygunConnection(raygunConnectionMock);
+        RaygunClient.SetOnBeforeSend(null);
 
+        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+        when(httpURLConnection.getResponseCode()).thenReturn(202);
+        requestBody = new ByteArrayOutputStream();
+        when(httpURLConnection.getOutputStream()).thenReturn(requestBody);
+        when(raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
     }
 
     @Test
     public void post_InvalidApiKeyExceptionCaught_MinusOneReturned() {
-        this.raygunClient = new RaygunServletClient("", requestMock);
-        assertEquals(-1, this.raygunClient.Send(new Exception()));
+        raygunClient = new RaygunServletClient("", requestMock);
+        assertEquals(-1, raygunClient.Send(new Exception()));
     }
 
     @Test
     public void post_AsyncWithInvalidKey_MinusOneReturned() {
-        this.raygunClient = new RaygunServletClient("", requestMock);
+        raygunClient = new RaygunServletClient("", requestMock);
 
         try {
             throw new Exception("Test");
         } catch (Exception e) {
-            this.raygunClient.SendAsync(e);
+            raygunClient.SendAsync(e);
         }
     }
 
     @Test
     public void post_ValidResponse_Returns202() throws MalformedURLException, IOException {
-        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-        when(httpURLConnection.getResponseCode()).thenReturn(202);
-        when(httpURLConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
-        when(this.raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
-
-        assertEquals(202, this.raygunClient.Send(new Exception()));
+        assertEquals(202, raygunClient.Send(new Exception()));
     }
 
     @Test
     public void send_WithTags_Returns202() throws MalformedURLException, IOException {
-        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-        when(httpURLConnection.getResponseCode()).thenReturn(202);
-        when(httpURLConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
-        when(this.raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
-
         List<String> tags = new ArrayList<String>();
         tags.add("test");
-        assertEquals(202, this.raygunClient.Send(new Exception(), tags));
+        assertEquals(202, raygunClient.Send(new Exception(), tags));
     }
 
     @Test
     public void send_WithTagsAndCustomData_Returns202() throws MalformedURLException, IOException {
-        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-        when(httpURLConnection.getResponseCode()).thenReturn(202);
-        when(httpURLConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
-        when(this.raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
-
         List<String> tags = new ArrayList<String>();
         tags.add("a_tag");
         Map<Integer, String> customData = new HashMap<Integer, String>();
         customData.put(0, "zero");
-        assertEquals(202, this.raygunClient.Send(new Exception(), tags, customData));
+        assertEquals(202, raygunClient.Send(new Exception(), tags, customData));
     }
-
 
     @Test
     public void send_WithoutUser_Returns202() throws MalformedURLException, IOException {
-        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-        when(httpURLConnection.getResponseCode()).thenReturn(202);
-        when(httpURLConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
-        when(this.raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
-
-        assertEquals(202, this.raygunClient.Send(new Exception()));
+        assertEquals(202, raygunClient.Send(new Exception()));
     }
 
     @Test
     public void send_WithUser_Returns202() throws MalformedURLException, IOException {
-        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-        when(httpURLConnection.getResponseCode()).thenReturn(202);
-        when(httpURLConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
-        when(this.raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
+        raygunClient.SetUser("abc");
 
-        this.raygunClient.SetUser("abc");
-
-        assertEquals(202, this.raygunClient.Send(new Exception()));
+        assertEquals(202, raygunClient.Send(new Exception()));
     }
 
     @Test
     public void send_WithQueryString_Returns202() throws MalformedURLException, IOException {
-        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-        when(httpURLConnection.getResponseCode()).thenReturn(202);
-        ByteArrayOutputStream requestBody = new ByteArrayOutputStream();
-        when(httpURLConnection.getOutputStream()).thenReturn(requestBody);
-        when(this.raygunConnectionMock.getConnection(Mockito.anyString())).thenReturn(httpURLConnection);
+        when(requestMock.getQueryString()).thenReturn("paramA=valueA&paramB=&");
 
-        when(this.requestMock.getQueryString()).thenReturn("paramA=valueA&paramB=&");
-
-        int send = this.raygunClient.Send(new Exception());
+        int send = raygunClient.Send(new Exception());
         assertEquals(202, send);
         String requestBodyAsString = requestBody.toString();
         assertEquals(true, requestBodyAsString.contains("paramA"));
         assertEquals(true, requestBodyAsString.contains("valueA"));
+    }
+
+    private void setupFilterMocks() {
+        when(requestMock.getQueryString()).thenReturn("queryParam1=queryValue1&queryParam2=queryValue2&queryParam3=queryValue3");
+
+        when(requestMock.getHeaderNames()).thenReturn(new Vector<String>(Arrays.asList("header1", "header2", "header3")).elements());
+        when(requestMock.getHeader("header1")).thenReturn("headerValue1");
+        when(requestMock.getHeader("header2")).thenReturn("headerValue2");
+        when(requestMock.getHeader("header3")).thenReturn("headerValue3");
+
+        when(requestMock.getParameterNames()).thenReturn(new Vector<String>(Arrays.asList("form1", "form2", "form3")).elements());
+        when(requestMock.getParameterValues("form1")).thenReturn(new String[]{"formValue1"});
+        when(requestMock.getParameterValues("form2")).thenReturn(new String[]{"formValue2"});
+        when(requestMock.getParameterValues("form3")).thenReturn(new String[]{"formValue3"});
+    }
+
+    @Test
+    public void send_WithOutFilters_FiltersRequest() {
+        setupFilterMocks();
+
+        int send = raygunClient.Send(new Exception());
+
+        String requestBodyAsString = requestBody.toString();
+        assertTrue(requestBodyAsString.contains("queryParam1"));
+        assertTrue(requestBodyAsString.contains("queryValue1"));
+        assertTrue(requestBodyAsString.contains("queryParam2"));
+        assertTrue(requestBodyAsString.contains("queryValue2"));
+        assertTrue(requestBodyAsString.contains("queryParam3"));
+        assertTrue(requestBodyAsString.contains("queryValue3"));
+
+        assertTrue(requestBodyAsString.contains("header1"));
+        assertTrue(requestBodyAsString.contains("headerValue1"));
+        assertTrue(requestBodyAsString.contains("header2"));
+        assertTrue(requestBodyAsString.contains("headerValue2"));
+        assertTrue(requestBodyAsString.contains("header3"));
+        assertTrue(requestBodyAsString.contains("headerValue3"));
+
+        assertTrue(requestBodyAsString.contains("form1"));
+        assertTrue(requestBodyAsString.contains("formValue1"));
+        assertTrue(requestBodyAsString.contains("form2"));
+        assertTrue(requestBodyAsString.contains("formValue2"));
+        assertTrue(requestBodyAsString.contains("form3"));
+        assertTrue(requestBodyAsString.contains("formValue3"));
+    }
+
+    @Test
+    public void send_WithFilters_FiltersRequest() {
+        setupFilterMocks();
+
+        raygunClient.SetOnBeforeSend(new RaygunOnBeforeSendChain()
+                .filterWith(new RaygunRequestQueryStringFilter("queryParam1", "queryParam2").replaceWith("*REDACTED*"))
+                .filterWith(new RaygunRequestHeaderFilter("header1", "header2").replaceWith("?"))
+                .filterWith(new RaygunRequestFormFilter("form1", "form2").replaceWith(""))
+        );
+
+        int send = raygunClient.Send(new Exception());
+
+        String requestBodyAsString = requestBody.toString();
+        assertTrue(requestBodyAsString.contains("queryParam1"));
+        assertTrue(requestBodyAsString.contains("*REDACTED*"));
+        assertTrue(requestBodyAsString.contains("queryParam2"));
+        assertFalse(requestBodyAsString.contains("queryValue2"));
+        assertTrue(requestBodyAsString.contains("queryParam3"));
+        assertTrue(requestBodyAsString.contains("queryValue3"));
+
+        assertTrue(requestBodyAsString.contains("header1"));
+        assertFalse(requestBodyAsString.contains("headerValue1"));
+        assertTrue(requestBodyAsString.contains("header2"));
+        assertFalse(requestBodyAsString.contains("headerValue2"));
+        assertTrue(requestBodyAsString.contains("header3"));
+        assertTrue(requestBodyAsString.contains("headerValue3"));
+
+        assertTrue(requestBodyAsString.contains("form1"));
+        assertFalse(requestBodyAsString.contains("formValue1"));
+        assertTrue(requestBodyAsString.contains("form2"));
+        assertFalse(requestBodyAsString.contains("formValue2"));
+        assertTrue(requestBodyAsString.contains("form3"));
+        assertTrue(requestBodyAsString.contains("formValue3"));
     }
 }


### PR DESCRIPTION
This PR adds data filtering ( inspired by https://github.com/MindscapeHQ/raygun4java/pull/31 )

While the ability to filter messages has been available for sometime with a roll your own implementation of `RaygunOnBeforeSend`, this PR adds some out of the box implementations:
*  `RaygunRequestQueryStringFilter` to filter out query string values
* `RaygunRequestHeaderFilter` to filter out header values
* `RaygunRequestFormFilter` to filter out form values

ie.
```
RaygunClient.SetOnBeforeSend(new RaygunRequestFormFilter("form1", "form2"));
```

And the bonus: `RaygunOnBeforeSendChain` which allows specifying a set of `RaygunOnBeforeSend` handlers:
```
RaygunClient.SetOnBeforeSend(new RaygunOnBeforeSendChain()
     .filterWith(new RaygunRequestQueryStringFilter("queryParam1", "queryParam2").replaceWith("*REDACTED*"))
     .filterWith(new RaygunRequestHeaderFilter("header1", "header2"))
     .filterWith(new RaygunRequestFormFilter("form1", "form2"))
```