### PR TITLE
adds support for extracting version from user class rather than the executing jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,15 @@ Tags can be null if you only wish to transmit custom data. Send calls can take t
 
 Raygun4Java reads the version of your application from your manifest.mf file in the calling package. It first attempts to read this from Specification-Version, then Implementation-Version if the first doesn't exist.
 
+In the case where your jar is not the main executing jar (ie. in a web container etc) you will have to pass in a class from your jar so that the correct version can be extracted ie
+```java
+client.SetVersionFrom(AClassFromMyApplication.class);
+```
+
 A SetVersion(string) method is also available to manually specify this version (for instance during testing). It is expected to be in the format X.X.X.X, where X is a positive integer.
+```java
+client.SetVersion("1.2.3.4");
+```
 
 ### Getting/setting/cancelling the error before it is sent
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,4 +23,13 @@
     <description>The official provider for the Raygun error tracking service. This core project is plugged in to your
         desktop, mobile or web application, and performs the actual sending.
     </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -70,6 +70,10 @@ public class RaygunClient {
         _version = version;
     }
 
+    public void SetVersionFrom(Class getVersionFrom) {
+        _version = new RaygunMessageBuilder().SetVersionFrom(getVersionFrom).Build().getDetails().getVersion();
+    }
+
     public int Send(Throwable throwable) {
         return Post(BuildMessage(throwable));
     }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunMessageBuilder.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunMessageBuilder.java
@@ -50,8 +50,14 @@ public class RaygunMessageBuilder implements IRaygunMessageBuilder {
         if (version != null) {
             _raygunMessage.getDetails().setVersion(version);
         } else {
-            _raygunMessage.getDetails().setVersion(ReadVersion());
+            _raygunMessage.getDetails().setVersion(ReadVersion(null));
         }
+        return this;
+    }
+
+    public IRaygunMessageBuilder SetVersionFrom(Class versionFrom) {
+        _raygunMessage.getDetails().setVersion(ReadVersion(versionFrom));
+
         return this;
     }
 
@@ -75,10 +81,16 @@ public class RaygunMessageBuilder implements IRaygunMessageBuilder {
         return this;
     }
 
-    private String ReadVersion() {
-        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
-        StackTraceElement main = stack[stack.length - 1];
-        String mainClass = main.getClassName();
+    private String ReadVersion(Class readVersionFrom) {
+
+        String mainClass;
+        if (readVersionFrom == null) {
+            StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+            StackTraceElement main = stack[stack.length - 1];
+            mainClass = main.getClassName();
+        } else {
+            mainClass = readVersionFrom.getName();
+        }
 
         try {
             Class<?> cl = getClass().getClassLoader().loadClass(mainClass);

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -1,5 +1,8 @@
 package com.mindscapehq.raygun4java.core;
 
+import com.google.gson.Gson;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -52,6 +55,13 @@ public class RaygunClientTest {
         this.raygunClient.SetUser("user");
 
         assertEquals(202, this.raygunClient.Send(new Exception()));
+    }
+
+    @Test
+    public void RaygunMessageDetailsGetVersion_FromClass_ReturnsClassManifestVersion() {
+        this.raygunClient.SetVersionFrom(org.apache.commons.io.IOUtils.class);
+
+        assertEquals("2.5", this.raygunClient._version);
     }
 
 }


### PR DESCRIPTION
This PR allows the passing of a user class to extract the jar version from.

The existing code was pulling the version out of the jar that was executing the main function. This works fine when you are running a console app or where you're not using a container.

When you add your jar to the classpath of a container such as Tomcat or Jetty or any other executing jar, then version would be read from the container jar version not the user version.

This PR allows the user to set the version by passing a user class to perform the manifest look up on.

```java
client.SetVersionFrom(AClassFromMyApplication.class);
```