### PR TITLE
XRAY-1889 Adds support for local host filtering on requests

### DIFF
--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -1,0 +1,58 @@
+package com.mindscapehq.raygun4java.webprovider;
+
+import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.RaygunOnBeforeSendChain;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunExcludeLocalRequestFilter;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestCookieFilter;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestFormFilter;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestHeaderFilter;
+import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestQueryStringFilter;
+
+import javax.servlet.ServletContext;
+
+/**
+ * A convenience class that provides fluent filter construction
+ */
+public class DefaultRaygunServletClientFactory extends RaygunServletClientFactory {
+    private final RaygunOnBeforeSendChain chain;
+
+    public DefaultRaygunServletClientFactory(String apiKey, ServletContext context) {
+        super(apiKey, context);
+        chain = new RaygunOnBeforeSendChain();
+        withBeforeSend(chain);
+    }
+
+    public DefaultRaygunServletClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend) {
+        super.withBeforeSend(onBeforeSend);
+        return this;
+    }
+
+    public DefaultRaygunServletClientFactory withLocalRequestsFilter() {
+        addFilter(new RaygunExcludeLocalRequestFilter());
+        return this;
+    }
+
+    public DefaultRaygunServletClientFactory withRequestFormFilters(String... fieldsToFilter) {
+        addFilter(new RaygunRequestFormFilter(fieldsToFilter));
+        return this;
+    }
+
+    public DefaultRaygunServletClientFactory withRequestHeaderFilters(String... fieldsToFilter) {
+        addFilter(new RaygunRequestHeaderFilter(fieldsToFilter));
+        return this;
+    }
+
+    public DefaultRaygunServletClientFactory withRequestQueryStringFilters(String... fieldsToFilter) {
+        addFilter(new RaygunRequestQueryStringFilter(fieldsToFilter));
+        return this;
+    }
+
+    public DefaultRaygunServletClientFactory withRequestCookieFilters(String... cookiesToFilter) {
+        addFilter(new RaygunRequestCookieFilter(cookiesToFilter));
+        return this;
+    }
+
+    private void addFilter(RaygunOnBeforeSend raygunOnBeforeSend) {
+        chain.getHandlers().add(raygunOnBeforeSend);
+    }
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -11,7 +11,12 @@ import com.mindscapehq.raygun4java.webprovider.filters.RaygunRequestQueryStringF
 import javax.servlet.ServletContext;
 
 /**
- * A convenience class that provides fluent filter construction
+ * A convenience class that provides fluent filter construction ie
+ * raygunClient = new DefaultRaygunServletClientFactory("1234", context))
+ *                 .withRequestFormFilters("form1", "form2")
+ *                 .withRequestHeaderFilters("header1", "header2")
+ *                 .withRequestQueryStringFilters("queryParam1", "queryParam2")
+ *                 .getClient(request);
  */
 public class DefaultRaygunServletClientFactory extends RaygunServletClientFactory {
     private final RaygunOnBeforeSendChain chain;

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
@@ -32,6 +32,10 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
         this.version = version;
     }
 
+    protected RaygunOnBeforeSend getOnBeforeSend() {
+        return onBeforeSend;
+    }
+
     /**
      * Add a RaygunOnBeforeSend handler
      *

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletMessageBuilder.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletMessageBuilder.java
@@ -43,7 +43,9 @@ public class RaygunServletMessageBuilder extends RaygunMessageBuilder implements
     public String getVersion(ServletContext context) {
         try {
             URL resource = context.getResource("/META-INF/MANIFEST.MF");
-            return readVersionFromManifest(resource.openStream());
+            if (resource != null) {
+                return readVersionFromManifest(resource.openStream());
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeLocalRequestFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeLocalRequestFilter.java
@@ -1,0 +1,17 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+
+/**
+ * Excludes requests that come from host names starting with "localhost"
+ */
+public class RaygunExcludeLocalRequestFilter extends RaygunExcludeRequestFilter {
+    private static final String LOCALHOST = "localhost";
+    public RaygunExcludeLocalRequestFilter() {
+        super(new Filter() {
+            public boolean shouldFilterOut(RaygunRequestMessage requestMessage) {
+                return requestMessage.getHostName().startsWith(LOCALHOST);
+            }
+        });
+    }
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeLocalRequestFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeLocalRequestFilter.java
@@ -10,7 +10,7 @@ public class RaygunExcludeLocalRequestFilter extends RaygunExcludeRequestFilter 
     public RaygunExcludeLocalRequestFilter() {
         super(new Filter() {
             public boolean shouldFilterOut(RaygunRequestMessage requestMessage) {
-                return requestMessage.getHostName().startsWith(LOCALHOST);
+                return requestMessage.getHostName().toLowerCase().startsWith(LOCALHOST);
             }
         });
     }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeRequestFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeRequestFilter.java
@@ -1,0 +1,35 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunServletMessageDetails;
+
+/**
+ * Discards the request if it matches the provided filter
+ */
+public class RaygunExcludeRequestFilter implements RaygunOnBeforeSend {
+
+    private Filter filter;
+
+    public RaygunExcludeRequestFilter(Filter filter) {
+        this.filter = filter;
+    }
+
+    public RaygunMessage OnBeforeSend(RaygunMessage message) {
+
+        if (message.getDetails() != null && message.getDetails() instanceof RaygunServletMessageDetails) {
+            RaygunServletMessageDetails requestMessageDetails = (RaygunServletMessageDetails) message.getDetails();
+
+            if (requestMessageDetails.getRequest() != null && filter.shouldFilterOut(requestMessageDetails.getRequest())) {
+                return null;
+            }
+        }
+
+        return message;
+    }
+
+    public interface Filter {
+        boolean shouldFilterOut(RaygunRequestMessage requestMessage);
+    }
+}

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeLocalRequestFilterTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/filters/RaygunExcludeLocalRequestFilterTest.java
@@ -1,0 +1,55 @@
+package com.mindscapehq.raygun4java.webprovider.filters;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunRequestMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunServletMessage;
+import com.mindscapehq.raygun4java.webprovider.RaygunServletMessageDetails;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RaygunExcludeLocalRequestFilterTest {
+
+    @Mock
+    HttpServletRequest req;
+    RaygunServletMessage localMessage;
+    RaygunServletMessageDetails details;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        localMessage = new RaygunServletMessage();
+        details = new RaygunServletMessageDetails();
+
+        req = mock(HttpServletRequest.class);
+    }
+
+
+    @Test
+    public void shouldExcludeLocalHostRequests() {
+        when(req.getRemoteHost()).thenReturn("localhost:9090");
+        RaygunRequestMessage request = new RaygunRequestMessage(req);
+        details.setRequest(request);
+        localMessage.setDetails(details);
+
+        assertNull(new RaygunExcludeLocalRequestFilter().OnBeforeSend(localMessage));
+    }
+
+    @Test
+    public void shouldNotExcludeNonLocalHostRequests() {
+        when(req.getRemoteHost()).thenReturn("www.myserver.com:9090");
+        RaygunRequestMessage request = new RaygunRequestMessage(req);
+        details.setRequest(request);
+        localMessage.setDetails(details);
+
+        assertNotNull(new RaygunExcludeLocalRequestFilter().OnBeforeSend(localMessage));
+    }
+}


### PR DESCRIPTION
This PR adds support to not set errors that occur on a localhost - ie developers machine.

It also adds a default factory that provides a fluent adding of filters:
```
raygunClient = new DefaultRaygunServletClientFactory("1234", context))
                .withLocalRequestsFilter()
                .withRequestFormFilters("form1", "form2")
                .withRequestHeaderFilters("header1", "header2")
                .withRequestQueryStringFilters("queryParam1", "queryParam2")
                .getClient(request);
```
