### PR TITLE
XRAY-1885 Adds support for http status filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,14 @@ factory.withBeforeSend(new RaygunStripWrappedExceptionFilter(ServletException.cl
 
 ### Web specific features
 
+#### Ignoring errors which specific http status code
+Sometimes unhandled exceptions are thrown that do not indicate an error. For example, an exception that represents a "Not Authorised" error might set a http status code of 401 onto the response.
+If you want to filter out errors by status code you can use the `RaygunRequestHttpStatusFilter` 
+
+```java
+factory.withBeforeSend(new RaygunRequestHttpStatusFilter(403, 401));
+```
+
 #### Ignoring errors from `localhost`
 Often developers will send errors from there local machine with the hostname `localhost`, if this is undesireable add the `RaygunExcludeLocalRequestFilter`
 ```java

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ new RaygunClient("YOUR_API_KEY").Send(new Exception("my first error"));
 ```
 While this is extremely simple, **that is not the recommended usage**: as your application complexity increases, scattering that code snippet throughout your code base will become unwieldy. A good practice is to encapsulate the setup and access to the `RaygunClient` instance in a factory. 
 
-Using a factory and dependency injection to manage your `RaygunClient` use will greatly reduce the complexity of your code. You can make your own factories you use the ones provided with allow the configuring of the main features on the factories, which will produce `RaygunClient`s with that configuration.
+Using a factory and dependency injection to manage your `RaygunClient` use will greatly reduce the complexity of your code. You can make your own factories or use the ones provided which allow the configuring of the main features on the factories, which will produce `RaygunClient`s with that configuration.
 
 For example:
 - Setup 
@@ -326,28 +326,6 @@ def index = Action { implicit request =>
 
 ## Documentation
 
-### Sending asynchronously
-
-Web projects that use `RaygunServletClient` can call `SendAsync()`, to transmit messages asynchronously. When `SendAsync` is called, the client will continue to perform the sending while control returns to the calling script or servlet. This allows the page to continue rendering and be returned to the end user while the exception message is trasmitted.
-
-####SendAsync()
-
-Overloads:
-
-```java
-void SendAsync(*Throwable* throwable)
-void SendAsync(*Throwable* throwable, *List* tags)
-void SendAsync(*Throwable* throwable, *List* tags, Map userCustomData)
-```
-
-This provides a huge speedup versus the blocking `Send()` method, and appears to be near instantaneous from the user's perspective.
-
-No HTTP status code is returned from this method as the calling thread will have terminated by the time the response is returned from the Raygun API. A logging option will be available in future.
-
-This feature is considered to be in Beta, and it is advised to test it in a staging environment before deploying to production. When in production it should be monitored to ensure no spurious behaviour (especially in high traffic scenarios) while the feature is in beta. Feedback is appreciated.
-
-**Google app engine:** This method will not work from code running on GAE - see the troubleshooting section below.
-
 ### Affected user tracking
 
 You can call `client.SetUser(RaygunIdentifier)` to set the current user's data, which will be displayed in the dashboard. There are two constructor overloads available, both of which requires a unique string as the `uniqueUserIdentifier`. This could be the user's email address if available, or an internally unique ID representing the users. Any errors containing this string will be considered to come from that user.
@@ -492,6 +470,28 @@ factory.withBeforeSend(new RaygunStripWrappedExceptionFilter(ServletException.cl
 
 
 ### Web specific features
+
+### Sending asynchronously
+
+Web projects that use `RaygunServletClient` can call `SendAsync()`, to transmit messages asynchronously. When `SendAsync` is called, the client will continue to perform the sending while control returns to the calling script or servlet. This allows the page to continue rendering and be returned to the end user while the exception message is trasmitted.
+
+####SendAsync()
+
+Overloads:
+
+```java
+void SendAsync(*Throwable* throwable)
+void SendAsync(*Throwable* throwable, *List* tags)
+void SendAsync(*Throwable* throwable, *List* tags, Map userCustomData)
+```
+
+This provides a huge speedup versus the blocking `Send()` method, and appears to be near instantaneous from the user's perspective.
+
+No HTTP status code is returned from this method as the calling thread will have terminated by the time the response is returned from the Raygun API. A logging option will be available in future.
+
+This feature is considered to be in Beta, and it is advised to test it in a staging environment before deploying to production. When in production it should be monitored to ensure no spurious behaviour (especially in high traffic scenarios) while the feature is in beta. Feedback is appreciated.
+
+**Google app engine:** This method will not work from code running on GAE - see the troubleshooting section below.
 
 #### Ignoring errors which specific http status code
 Sometimes unhandled exceptions are thrown that do not indicate an error. For example, an exception that represents a "Not Authorised" error might set a http status code of 401 onto the response.

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ public class MyProgram {
 
 In the example above, the overridden `OnBeforeSend` method will log an info message every time an error is sent.
 
+### Mutate the error payload
 To mutate the error payload, for instance to change the message:
 
 ```java
@@ -421,6 +422,7 @@ public RaygunMessage OnBeforeSend(RaygunMessage message) {
 }
 ```
 
+### Cancel the send
 To cancel the send (prevent the error from reaching the Raygun dashboard) by returning null:
 
 ```java
@@ -431,7 +433,8 @@ public RaygunMessage OnBeforeSend(RaygunMessage message) {
 }
 ```
 
-There are several provided classes for filtering, and use can use the `RaygunOnBeforeSendChain` to execute multiple `RaygunOnBeforeSend`
+### Filtering
+There are several [provided classes for filtering](https://github.com/MindscapeHQ/raygun4java/tree/master/core/src/main/java/com/mindscapehq/raygun4java/core/filters), and you can use the `RaygunOnBeforeSendChain` to execute multiple `RaygunOnBeforeSend`
 ```java
 raygunClient.SetOnBeforeSend(new RaygunOnBeforeSendChain()
         .filterWith(new RaygunRequestQueryStringFilter("queryParam1", "queryParam2").replaceWith("*REDACTED*"))
@@ -471,11 +474,23 @@ factory.withBeforeSend(new RaygunStripWrappedExceptionFilter(ServletException.cl
 
 ### Web specific features
 
-### Sending asynchronously
+#### Web specific factory
+The `webprovider` dependency adds a `DefaultRaygunServletClientFactory` which exposes convenience methods to add the provided filters.
+
+```java
+IRaygunServletClientFactory factory = new DefaultRaygunServletClientFactory("YOUR_APP_API_KEY", servletContext)
+    .withLocalRequestsFilter()
+    .withRequestFormFilters("password", "ssn", "creditcard")
+    .withRequestHeaderFilters("auth")
+    .withRequestQueryStringFilters("secret")
+    .withRequestCookieFilters("sessionId")
+    .withWrappedExceptionStripping(ServletException.class)
+    .withHttpStatusFiltering(200, 401, 403)
+    .addFilter(myOnBeforeSendHandler)
+```
+#### Sending asynchronously
 
 Web projects that use `RaygunServletClient` can call `SendAsync()`, to transmit messages asynchronously. When `SendAsync` is called, the client will continue to perform the sending while control returns to the calling script or servlet. This allows the page to continue rendering and be returned to the end user while the exception message is trasmitted.
-
-####SendAsync()
 
 Overloads:
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
@@ -1,0 +1,10 @@
+package com.mindscapehq.raygun4java.core;
+
+public interface IRaygunClientFactory {
+    IRaygunClientFactory withApiKey(String apiKey);
+    IRaygunClientFactory withVersion(String version);
+    IRaygunClientFactory withVersionFrom(Class versionFromClass);
+    IRaygunClientFactory withMessageBuilder(IRaygunMessageBuilderFactory messageBuilderFactory);
+    IRaygunClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend);
+    RaygunClient newClient();
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunMessageBuilder.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunMessageBuilder.java
@@ -20,6 +20,8 @@ public interface IRaygunMessageBuilder {
 
     IRaygunMessageBuilder SetVersion(String version);
 
+    IRaygunMessageBuilder SetVersionFrom(Class versionFrom);
+
     IRaygunMessageBuilder SetTags(List<?> tags);
 
     IRaygunMessageBuilder SetUserCustomData(Map<?, ?> userCustomData);

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunMessageBuilderFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunMessageBuilderFactory.java
@@ -1,0 +1,5 @@
+package com.mindscapehq.raygun4java.core;
+
+public interface IRaygunMessageBuilderFactory {
+    IRaygunMessageBuilder newMessageBuilder();
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunExcludeLocalRequestFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunExcludeLocalRequestFilter.java
@@ -1,6 +1,7 @@
 package com.mindscapehq.raygun4java.core.filters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
+import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 
 /**
  * Excludes requests that come from host names starting with "localhost"
@@ -9,8 +10,8 @@ public class RaygunExcludeLocalRequestFilter extends RaygunExcludeRequestFilter 
     private static final String LOCALHOST = "localhost";
     public RaygunExcludeLocalRequestFilter() {
         super(new Filter() {
-            public boolean shouldFilterOut(RaygunRequestMessage requestMessage) {
-                return requestMessage.getHostName().toLowerCase().startsWith(LOCALHOST);
+            public boolean shouldFilterOut(RaygunRequestMessageDetails requestMessage) {
+                return requestMessage.getRequest().getHostName().toLowerCase().startsWith(LOCALHOST);
             }
         });
     }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunExcludeRequestFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunExcludeRequestFilter.java
@@ -2,7 +2,6 @@ package com.mindscapehq.raygun4java.core.filters;
 
 import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
-import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 
 /**
@@ -21,7 +20,7 @@ public class RaygunExcludeRequestFilter implements RaygunOnBeforeSend {
         if (message.getDetails() != null && message.getDetails() instanceof RaygunRequestMessageDetails) {
             RaygunRequestMessageDetails requestMessageDetails = (RaygunRequestMessageDetails) message.getDetails();
 
-            if (requestMessageDetails.getRequest() != null && filter.shouldFilterOut(requestMessageDetails.getRequest())) {
+            if (requestMessageDetails.getRequest() != null && filter.shouldFilterOut(requestMessageDetails)) {
                 return null;
             }
         }
@@ -30,6 +29,6 @@ public class RaygunExcludeRequestFilter implements RaygunOnBeforeSend {
     }
 
     public interface Filter {
-        boolean shouldFilterOut(RaygunRequestMessage requestMessage);
+        boolean shouldFilterOut(RaygunRequestMessageDetails requestMessage);
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunRequestHttpStatusFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunRequestHttpStatusFilter.java
@@ -1,0 +1,32 @@
+package com.mindscapehq.raygun4java.core.filters;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+/**
+ * Will filter out errors with the given http status codes
+ */
+public class RaygunRequestHttpStatusFilter extends RaygunExcludeRequestFilter {
+
+    public RaygunRequestHttpStatusFilter(final Integer... excludeHttpCodes) {
+        super(new ExcludeHttpCodesFilter(excludeHttpCodes));
+    }
+
+    private static class ExcludeHttpCodesFilter implements Filter {
+        private HashSet<Integer> excludedCodes;
+        private ExcludeHttpCodesFilter(final Integer... excludeHttpCodes) {
+            excludedCodes = new HashSet<Integer>();
+            Collections.addAll(excludedCodes, excludeHttpCodes);
+        }
+
+        public boolean shouldFilterOut(RaygunRequestMessageDetails requestMessage) {
+            if (requestMessage.getResponse() != null
+                    && requestMessage.getResponse().getStatusCode() != null) {
+                return excludedCodes.contains(requestMessage.getResponse().getStatusCode());
+            }
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunRequestMessageDetails.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunRequestMessageDetails.java
@@ -3,6 +3,7 @@ package com.mindscapehq.raygun4java.core.messages;
 public class RaygunRequestMessageDetails extends RaygunMessageDetails {
 
     private RaygunRequestMessage request;
+    private RaygunResponseMessage response;
 
     public RaygunRequestMessage getRequest() {
         return request;
@@ -10,5 +11,13 @@ public class RaygunRequestMessageDetails extends RaygunMessageDetails {
 
     public void setRequest(RaygunRequestMessage request) {
         this.request = request;
+    }
+
+    public RaygunResponseMessage getResponse() {
+        return response;
+    }
+
+    public void setResponse(RaygunResponseMessage response) {
+        this.response = response;
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunResponseMessage.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunResponseMessage.java
@@ -1,0 +1,17 @@
+package com.mindscapehq.raygun4java.core.messages;
+
+public class RaygunResponseMessage {
+    private Integer statusCode;
+
+    public RaygunResponseMessage(Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+}

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/filters/RaygunRequestHttpStatusFilterTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/filters/RaygunRequestHttpStatusFilterTest.java
@@ -1,0 +1,41 @@
+package com.mindscapehq.raygun4java.core.filters;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessageDetails;
+import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
+import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
+import com.mindscapehq.raygun4java.core.messages.RaygunResponseMessage;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+
+public class RaygunRequestHttpStatusFilterTest {
+    @Test
+    public void shouldFilterOutOnHttpStatusCode() {
+        RaygunRequestHttpStatusFilter filter = new RaygunRequestHttpStatusFilter(200, 404, 400);
+
+        RaygunMessage message = new RaygunMessage();
+        RaygunRequestMessageDetails requestDetails = new RaygunRequestMessageDetails();
+        RaygunResponseMessage response = new RaygunResponseMessage(404);
+        requestDetails.setRequest(new RaygunRequestMessage());
+        requestDetails.setResponse(response);
+        message.setDetails(requestDetails);
+        assertNull(filter.OnBeforeSend(message));
+    }
+
+    @Test
+    public void shouldNotFilterOutOnHttpStatusCode() {
+        RaygunRequestHttpStatusFilter filter = new RaygunRequestHttpStatusFilter(200, 404, 400);
+
+        RaygunMessage message = new RaygunMessage();
+        RaygunRequestMessageDetails requestDetails = new RaygunRequestMessageDetails();
+        RaygunResponseMessage response = new RaygunResponseMessage(202);
+        requestDetails.setResponse(response);
+        requestDetails.setRequest(new RaygunRequestMessage());
+        message.setDetails(requestDetails);
+        assertThat(message, is(message));
+    }
+
+}

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -5,6 +5,7 @@ import com.mindscapehq.raygun4java.core.RaygunOnBeforeSendChain;
 import com.mindscapehq.raygun4java.core.filters.RaygunRequestCookieFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunRequestFormFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunRequestHeaderFilter;
+import com.mindscapehq.raygun4java.core.filters.RaygunRequestHttpStatusFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunRequestQueryStringFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunExcludeLocalRequestFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunStripWrappedExceptionFilter;
@@ -63,7 +64,12 @@ public class DefaultRaygunServletClientFactory extends RaygunServletClientFactor
         return this;
     }
 
-    private void addFilter(RaygunOnBeforeSend raygunOnBeforeSend) {
+    public DefaultRaygunServletClientFactory withHttpStatusFiltering(Integer... excludeStatusCodes) {
+        addFilter(new RaygunRequestHttpStatusFilter(excludeStatusCodes));
+        return this;
+    }
+
+    public void addFilter(RaygunOnBeforeSend raygunOnBeforeSend) {
         chain.getHandlers().add(raygunOnBeforeSend);
     }
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletFilterFacade.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletFilterFacade.java
@@ -1,14 +1,22 @@
 package com.mindscapehq.raygun4java.webprovider;
 
 import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * An out-of-the-box RaygunServletFilterFacade implementation that uses the RaygunClient static accessors - ensure that RaygunClient has been initialized
  */
 public class DefaultRaygunServletFilterFacade implements IRaygunServletFilterFacade {
-    public void initializeRequest(ServletRequest servletRequest) {
-        RaygunClient.initialize((HttpServletRequest)servletRequest);
+    public void initializeRequest(HttpServletRequest servletRequest) {
+        RaygunClient.initialize(servletRequest);
+    }
+
+    public void setCommittedResponse(HttpServletResponse response) {
+        try {
+            RaygunClient.get().setResponse(response);
+        } catch (Exception raygunException){}
     }
 
     public void send(Throwable throwable) {

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunHttpMessageBuilder.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunHttpMessageBuilder.java
@@ -3,7 +3,8 @@ package com.mindscapehq.raygun4java.webprovider;
 import com.mindscapehq.raygun4java.core.IRaygunMessageBuilder;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public interface IRaygunHttpMessageBuilder extends IRaygunMessageBuilder {
-    IRaygunHttpMessageBuilder SetRequestDetails(HttpServletRequest request);
+    IRaygunHttpMessageBuilder SetRequestDetails(HttpServletRequest request, HttpServletResponse response);
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
@@ -1,10 +1,14 @@
 package com.mindscapehq.raygun4java.webprovider;
 
+import com.mindscapehq.raygun4java.core.IRaygunClientFactory;
 import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-public interface IRaygunServletClientFactory {
+public interface IRaygunServletClientFactory extends IRaygunClientFactory {
     RaygunServletClient getClient(HttpServletRequest request);
     IRaygunServletClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend);
+    IRaygunServletClientFactory withVersionFrom(ServletContext context);
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletFilterFacade.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletFilterFacade.java
@@ -1,9 +1,11 @@
 package com.mindscapehq.raygun4java.webprovider;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public interface IRaygunServletFilterFacade {
-    void initializeRequest(ServletRequest servletRequest);
+    void initializeRequest(HttpServletRequest servletRequest);
+    void setCommittedResponse(HttpServletResponse servletResponse);
     void send(Throwable throwable);
     void done();
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
@@ -80,8 +80,8 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
     /**
      * @return a new RaygunClient
      */
-    public RaygunServletClient getClient(HttpServletRequest request, HttpServletResponse response) {
-        RaygunServletClient client = new RaygunServletClient(apiKey, request, response);
+    public RaygunServletClient getClient(HttpServletRequest request) {
+        RaygunServletClient client = new RaygunServletClient(apiKey, request);
         client.SetOnBeforeSend(onBeforeSend);
         client.SetVersion(version);
         return client;

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletFilter.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletFilter.java
@@ -7,6 +7,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
@@ -28,10 +29,14 @@ public class RaygunServletFilter implements Filter {
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         try {
             if (servletRequest instanceof HttpServletRequest) {
-                raygunServletFilterFacade.initializeRequest(servletRequest);
+                raygunServletFilterFacade.initializeRequest((HttpServletRequest)servletRequest);
             }
             filterChain.doFilter(servletRequest, servletResponse);
         } catch (Throwable ex) {
+            if (servletResponse instanceof HttpServletResponse) {
+                raygunServletFilterFacade.setCommittedResponse((HttpServletResponse) servletResponse);
+            }
+
             raygunServletFilterFacade.send(ex);
 
             if (ex instanceof ServletException) throw (ServletException)ex;

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletMessageBuilder.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletMessageBuilder.java
@@ -1,11 +1,11 @@
 package com.mindscapehq.raygun4java.webprovider;
 
 import com.mindscapehq.raygun4java.core.RaygunMessageBuilder;
+import com.mindscapehq.raygun4java.core.messages.RaygunResponseMessage;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import java.io.InputStream;
-import java.net.MalformedURLException;
+import javax.servlet.http.HttpServletResponse;
 import java.net.URL;
 
 public class RaygunServletMessageBuilder extends RaygunMessageBuilder implements IRaygunHttpMessageBuilder {
@@ -34,8 +34,12 @@ public class RaygunServletMessageBuilder extends RaygunMessageBuilder implements
         return _raygunServletMessage;
     }
 
-    public IRaygunHttpMessageBuilder SetRequestDetails(HttpServletRequest request) {
+    public IRaygunHttpMessageBuilder SetRequestDetails(HttpServletRequest request, HttpServletResponse response) {
         _raygunServletMessage.getDetails().setRequest(new RaygunRequestMessage(request));
+
+        if(response != null) {
+            _raygunServletMessage.getDetails().setResponse(new RaygunResponseMessage(response.getStatus()));
+        }
 
         return this;
     }

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletFilterFacadeTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletFilterFacadeTest.java
@@ -1,12 +1,10 @@
 package com.mindscapehq.raygun4java.webprovider;
 
-import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import javax.servlet.http.HttpServletRequest;

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
@@ -22,13 +22,12 @@ import static org.mockito.Mockito.when;
 public class RaygunServletClientFactoryTest {
 
     private final String apiKey = "aPiKeY";
-    private HttpServletRequest request;
 
     @Test
     public void shouldInitializeWithVersion() {
-        RaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey, "thisVersion");
+        IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withVersion("thisVersion");
 
-        RaygunServletClient client = factory.getClient(request);
+        RaygunServletClient client = factory.getClient(null);
 
         assertThat(client.getVersion(), is("thisVersion"));
         assertThat(client.getApiKey(), is(apiKey));
@@ -36,9 +35,9 @@ public class RaygunServletClientFactoryTest {
 
     @Test
     public void shouldInitializeWithVersionFromClass() {
-        RaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey, org.apache.commons.io.IOUtils.class);
+        IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withVersionFrom(org.apache.commons.io.IOUtils.class);
 
-        RaygunServletClient client = factory.getClient(request);
+        RaygunServletClient client = factory.getClient(null);
 
         assertThat(client.getVersion(), is("2.5"));
         assertThat(client.getApiKey(), is(apiKey));
@@ -48,9 +47,9 @@ public class RaygunServletClientFactoryTest {
     public void shouldInitializeWithOnBeforeSend() {
 
         RaygunOnBeforeSend handler = mock(RaygunOnBeforeSend.class);
-        RaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey, "thisVersion").withBeforeSend(handler);
+        IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withBeforeSend(handler);
 
-        RaygunServletClient client = factory.getClient(request);
+        RaygunServletClient client = factory.getClient(null);
 
         assertThat(client.getOnBeforeSend(), is(handler));
     }

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
@@ -4,7 +4,9 @@ import com.mindscapehq.raygun4java.core.RaygunConnection;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.ServletContext;
@@ -26,13 +28,16 @@ public class RaygunServletClientTest {
     private RaygunServletClient raygunClient;
 
     private RaygunConnection raygunConnectionMock;
-    private HttpServletRequest requestMock;
+    @Mock
+    private HttpServletRequest request;
+
     private ByteArrayOutputStream requestBody;
 
     @Before
     public void setUp() throws IOException {
-        requestMock = mock(HttpServletRequest.class);
-        raygunClient = new RaygunServletClient("1234", requestMock);
+        MockitoAnnotations.initMocks(this);
+
+        raygunClient = new RaygunServletClient("1234", request);
         raygunConnectionMock = mock(RaygunConnection.class);
         raygunClient.setRaygunConnection(raygunConnectionMock);
         raygunClient.SetOnBeforeSend(null);
@@ -46,13 +51,13 @@ public class RaygunServletClientTest {
 
     @Test
     public void post_InvalidApiKeyExceptionCaught_MinusOneReturned() {
-        raygunClient = new RaygunServletClient("", requestMock);
+        raygunClient = new RaygunServletClient("", request);
         assertEquals(-1, raygunClient.Send(new Exception()));
     }
 
     @Test
     public void post_AsyncWithInvalidKey_MinusOneReturned() {
-        raygunClient = new RaygunServletClient("", requestMock);
+        raygunClient = new RaygunServletClient("", request);
 
         try {
             throw new Exception("Test");
@@ -96,7 +101,7 @@ public class RaygunServletClientTest {
 
     @Test
     public void send_WithQueryString_Returns202() throws MalformedURLException, IOException {
-        when(requestMock.getQueryString()).thenReturn("paramA=valueA&paramB=&");
+        when(request.getQueryString()).thenReturn("paramA=valueA&paramB=&");
 
         int send = raygunClient.Send(new Exception());
         assertEquals(202, send);
@@ -106,23 +111,23 @@ public class RaygunServletClientTest {
     }
 
     private void setupFilterMocks() {
-        when(requestMock.getQueryString()).thenReturn("queryParam1=queryValue1&queryParam2=queryValue2&queryParam3=queryValue3");
+        when(request.getQueryString()).thenReturn("queryParam1=queryValue1&queryParam2=queryValue2&queryParam3=queryValue3");
 
-        when(requestMock.getHeaderNames()).thenReturn(new Vector<String>(Arrays.asList("header1", "header2", "header3")).elements());
-        when(requestMock.getHeader("header1")).thenReturn("headerValue1");
-        when(requestMock.getHeader("header2")).thenReturn("headerValue2");
-        when(requestMock.getHeader("header3")).thenReturn("headerValue3");
-        when(requestMock.getHeader("Cookies")).thenReturn("someCookies");
+        when(request.getHeaderNames()).thenReturn(new Vector<String>(Arrays.asList("header1", "header2", "header3")).elements());
+        when(request.getHeader("header1")).thenReturn("headerValue1");
+        when(request.getHeader("header2")).thenReturn("headerValue2");
+        when(request.getHeader("header3")).thenReturn("headerValue3");
+        when(request.getHeader("Cookies")).thenReturn("someCookies");
 
         Cookie[] cookies = new Cookie[2];
         cookies[0] = new Cookie("cookie1", "cookieValue1");
         cookies[1] = new Cookie("cookie2", "cookieValue2");
-        when(requestMock.getCookies()).thenReturn(cookies);
+        when(request.getCookies()).thenReturn(cookies);
 
-        when(requestMock.getParameterNames()).thenReturn(new Vector<String>(Arrays.asList("form1", "form2", "form3")).elements());
-        when(requestMock.getParameterValues("form1")).thenReturn(new String[]{"formValue1"});
-        when(requestMock.getParameterValues("form2")).thenReturn(new String[]{"formValue2"});
-        when(requestMock.getParameterValues("form3")).thenReturn(new String[]{"formValue3"});
+        when(request.getParameterNames()).thenReturn(new Vector<String>(Arrays.asList("form1", "form2", "form3")).elements());
+        when(request.getParameterValues("form1")).thenReturn(new String[]{"formValue1"});
+        when(request.getParameterValues("form2")).thenReturn(new String[]{"formValue2"});
+        when(request.getParameterValues("form3")).thenReturn(new String[]{"formValue3"});
     }
 
     @Test
@@ -168,7 +173,7 @@ public class RaygunServletClientTest {
                 .withRequestHeaderFilters("header1", "header2")
                 .withRequestQueryStringFilters("queryParam1", "queryParam2")
                 .withRequestCookieFilters("cookie2")
-                .getClient(requestMock);
+                .getClient(request);
         raygunClient.setRaygunConnection(raygunConnectionMock);
 
         int send = raygunClient.Send(new Exception());


### PR DESCRIPTION
Sometimes unhandled exceptions are thrown that do not indicate an error. For example, an exception that represents a "Not Authorised" error might set a http status code of 401 onto the response.
If you want to filter out errors by status code you can use the `RaygunRequestHttpStatusFilter` 

```java
factory.withBeforeSend(new RaygunRequestHttpStatusFilter(403, 401));
```

This PR also adds several readme and factory tweeks