### PR TITLE
XRAY-1902 Adds support for detecting already send errors

### DIFF
--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
@@ -6,5 +6,9 @@ public interface IRaygunClientFactory {
     IRaygunClientFactory withVersionFrom(Class versionFromClass);
     IRaygunClientFactory withMessageBuilder(IRaygunMessageBuilderFactory messageBuilderFactory);
     IRaygunClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend);
+    IRaygunClientFactory withAfterSend(IRaygunOnAfterSend onAfterSend);
+
     RaygunClient newClient();
+    RaygunOnBeforeSendChain getRaygunOnBeforeSendChain();
+    RaygunOnAfterSendChain getRaygunOnAfterSendChain();
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
@@ -5,6 +5,6 @@ public interface IRaygunClientFactory {
     IRaygunClientFactory withVersion(String version);
     IRaygunClientFactory withVersionFrom(Class versionFromClass);
     IRaygunClientFactory withMessageBuilder(IRaygunMessageBuilderFactory messageBuilderFactory);
-    IRaygunClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend);
+    IRaygunClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend);
     RaygunClient newClient();
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnAfterSend.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnAfterSend.java
@@ -1,0 +1,7 @@
+package com.mindscapehq.raygun4java.core;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+
+public interface IRaygunOnAfterSend {
+    RaygunMessage onAfterSend(RaygunMessage message);
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnBeforeSend.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnBeforeSend.java
@@ -2,6 +2,6 @@ package com.mindscapehq.raygun4java.core;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
-public interface RaygunOnBeforeSend {
+public interface IRaygunOnBeforeSend {
     RaygunMessage onBeforeSend(RaygunMessage message);
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -28,7 +28,7 @@ public class RaygunClient {
     protected RaygunIdentifier user;
     protected String context;
     protected String string = null;
-    protected RaygunOnBeforeSend onBeforeSend;
+    protected IRaygunOnBeforeSend onBeforeSend;
 
     public RaygunClient(String apiKey) {
         this.apiKey = apiKey;
@@ -126,7 +126,7 @@ public class RaygunClient {
         return -1;
     }
 
-    public void setOnBeforeSend(RaygunOnBeforeSend onBeforeSend) {
+    public void setOnBeforeSend(IRaygunOnBeforeSend onBeforeSend) {
         this.onBeforeSend = onBeforeSend;
     }
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -29,6 +29,7 @@ public class RaygunClient {
     protected String context;
     protected String string = null;
     protected IRaygunOnBeforeSend onBeforeSend;
+    private IRaygunOnAfterSend onAfterSend;
 
     public RaygunClient(String apiKey) {
         this.apiKey = apiKey;
@@ -117,6 +118,15 @@ public class RaygunClient {
                 writer.flush();
                 writer.close();
                 connection.disconnect();
+
+                try {
+                    if(onAfterSend != null) {
+                        onAfterSend.onAfterSend(raygunMessage);
+                    }
+                } catch (Exception e) {
+                    Logger.getLogger("Raygun4Java").warning("exception processing onAfterSend: " + e.getMessage());
+                }
+
                 return connection.getResponseCode();
 
             }
@@ -128,6 +138,10 @@ public class RaygunClient {
 
     public void setOnBeforeSend(IRaygunOnBeforeSend onBeforeSend) {
         this.onBeforeSend = onBeforeSend;
+    }
+
+    public void setOnAfterSend(IRaygunOnAfterSend onAfterSend) {
+        this.onAfterSend = onAfterSend;
     }
 
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -29,7 +29,7 @@ public class RaygunClient {
     protected String context;
     protected String string = null;
     protected IRaygunOnBeforeSend onBeforeSend;
-    private IRaygunOnAfterSend onAfterSend;
+    protected IRaygunOnAfterSend onAfterSend;
 
     public RaygunClient(String apiKey) {
         this.apiKey = apiKey;
@@ -144,6 +144,13 @@ public class RaygunClient {
         this.onAfterSend = onAfterSend;
     }
 
+    public IRaygunOnBeforeSend getOnBeforeSend() {
+        return onBeforeSend;
+    }
+
+    public IRaygunOnAfterSend getOnAfterSend() {
+        return onAfterSend;
+    }
 
     String getVersion() {
         return string;

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
@@ -1,5 +1,7 @@
 package com.mindscapehq.raygun4java.core;
 
+import com.mindscapehq.raygun4java.core.filters.RaygunDuplicateErrorFilter;
+
 /**
  * An out-of-the-box RaygunClient factory.
  *
@@ -32,8 +34,11 @@ public class RaygunClientFactory implements IRaygunClientFactory {
         this.apiKey = apiKey;
         version = new RaygunMessageBuilder().setVersion(null).build().getDetails().getVersion();
 
-        onBeforeSendChain = new RaygunOnBeforeSendChain();
+        RaygunDuplicateErrorFilter duplicateErrorFilter = new RaygunDuplicateErrorFilter();
+
+        onBeforeSendChain = new RaygunOnBeforeSendChain().afterAll(duplicateErrorFilter);
         onAfterSendChain = new RaygunOnAfterSendChain();
+        onAfterSendChain.handleWith(duplicateErrorFilter);
     }
 
     /**
@@ -68,6 +73,7 @@ public class RaygunClientFactory implements IRaygunClientFactory {
     public RaygunClient newClient() {
         RaygunClient client = new RaygunClient(apiKey);
         client.setOnBeforeSend(onBeforeSendChain);
+        client.setOnAfterSend(onAfterSendChain);
         client.string = version;
         return client;
     }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
@@ -40,8 +40,8 @@ public class RaygunClientFactory implements IRaygunClientFactory {
      * @param onBeforeSend
      * @return factory
      */
-    public RaygunClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend) {
         this.onBeforeSend = onBeforeSend;
+    public RaygunClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend) {
         return this;
     }
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnAfterSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnAfterSendChain.java
@@ -1,0 +1,40 @@
+package com.mindscapehq.raygun4java.core;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RaygunOnAfterSendChain implements IRaygunOnAfterSend {
+
+    private List<IRaygunOnAfterSend> handlers;
+
+    public RaygunOnAfterSendChain() {
+        this(new ArrayList<IRaygunOnAfterSend>());
+    }
+
+    public RaygunOnAfterSendChain(List<IRaygunOnAfterSend> handlers) {
+        this.handlers = handlers;
+    }
+
+    public RaygunMessage onBeforeSend(RaygunMessage message) {
+        for (IRaygunOnAfterSend raygunOnBeforeSend : getHandlers()) {
+            message = raygunOnBeforeSend.onAfterSend(message);
+        }
+
+        return message;
+    }
+
+    public List<IRaygunOnAfterSend> getHandlers() {
+        return handlers;
+    }
+
+    public RaygunOnAfterSendChain handleWith(IRaygunOnAfterSend handler) {
+        handlers.add(handler);
+        return this;
+    }
+
+    public RaygunMessage onAfterSend(RaygunMessage message) {
+        return null;
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnAfterSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnAfterSendChain.java
@@ -5,9 +5,23 @@ import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Chains multiple after-send handlers
+ * usage:
+ * raygunClient.setOnAfterSend(
+ *      new RaygunOnAfterSendChain()
+ *          .filterWith(doThis),
+ *          .filterWith(andThis)
+ *      )
+ *      .beforeAll(doThisFirst)
+ *      .afterAll(doThisLast)
+ * );
+ */
 public class RaygunOnAfterSendChain implements IRaygunOnAfterSend {
 
     private List<IRaygunOnAfterSend> handlers;
+    private IRaygunOnAfterSend lastHandler;
+    private IRaygunOnAfterSend firstHandler;
 
     public RaygunOnAfterSendChain() {
         this(new ArrayList<IRaygunOnAfterSend>());
@@ -17,24 +31,68 @@ public class RaygunOnAfterSendChain implements IRaygunOnAfterSend {
         this.handlers = handlers;
     }
 
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
-        for (IRaygunOnAfterSend raygunOnBeforeSend : getHandlers()) {
-            message = raygunOnBeforeSend.onAfterSend(message);
-        }
-
-        return message;
-    }
-
-    public List<IRaygunOnAfterSend> getHandlers() {
-        return handlers;
-    }
-
     public RaygunOnAfterSendChain handleWith(IRaygunOnAfterSend handler) {
         handlers.add(handler);
         return this;
     }
 
     public RaygunMessage onAfterSend(RaygunMessage message) {
-        return null;
+        if(firstHandler != null) {
+            firstHandler.onAfterSend(message);
+        }
+
+        for (IRaygunOnAfterSend raygunOnAfterSend : getHandlers()) {
+            message = raygunOnAfterSend.onAfterSend(message);
+        }
+
+        if(lastHandler != null) {
+            lastHandler.onAfterSend(message);
+        }
+
+        return message;
+    }
+
+    /**
+     * Perform a specific handler before the other handlers
+     * @param firstHandler
+     * @return
+     */
+    public RaygunOnAfterSendChain beforeAll(IRaygunOnAfterSend firstHandler) {
+        this.firstHandler = firstHandler;
+        return this;
+    }
+
+    /**
+     * Perform a specific handler after the other handlers
+     * @param lastHandler
+     * @return
+     */
+    public RaygunOnAfterSendChain afterAll(IRaygunOnAfterSend lastHandler) {
+        this.lastHandler = lastHandler;
+        return this;
+    }
+
+    public List<IRaygunOnAfterSend> getHandlers() {
+        return handlers;
+    }
+
+    public void setHandlers(List<IRaygunOnAfterSend> handlers) {
+        this.handlers = handlers;
+    }
+
+    public IRaygunOnAfterSend getLastHandler() {
+        return lastHandler;
+    }
+
+    public void setLastHandler(IRaygunOnAfterSend lastHandler) {
+        this.lastHandler = lastHandler;
+    }
+
+    public IRaygunOnAfterSend getFirstHandler() {
+        return firstHandler;
+    }
+
+    public void setFirstHandler(IRaygunOnAfterSend firstHandler) {
+        this.firstHandler = firstHandler;
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
@@ -15,31 +15,31 @@ import java.util.List;
  *          ....
  * );
  */
-public class RaygunOnBeforeSendChain implements RaygunOnBeforeSend {
+public class RaygunOnBeforeSendChain implements IRaygunOnBeforeSend {
 
-    private List<RaygunOnBeforeSend> handlers;
+    private List<IRaygunOnBeforeSend> handlers;
 
     public RaygunOnBeforeSendChain() {
-        this(new ArrayList<RaygunOnBeforeSend>());
+        this(new ArrayList<IRaygunOnBeforeSend>());
     }
 
-    public RaygunOnBeforeSendChain(List<RaygunOnBeforeSend> handlers) {
+    public RaygunOnBeforeSendChain(List<IRaygunOnBeforeSend> handlers) {
         this.handlers = handlers;
     }
 
     public RaygunMessage onBeforeSend(RaygunMessage message) {
-        for (RaygunOnBeforeSend raygunOnBeforeSend : getHandlers()) {
+        for (IRaygunOnBeforeSend raygunOnBeforeSend : getHandlers()) {
             message = raygunOnBeforeSend.onBeforeSend(message);
         }
 
         return message;
     }
 
-    public List<RaygunOnBeforeSend> getHandlers() {
+    public List<IRaygunOnBeforeSend> getHandlers() {
         return handlers;
     }
 
-    public RaygunOnBeforeSendChain filterWith(RaygunOnBeforeSend handler) {
+    public RaygunOnBeforeSendChain filterWith(IRaygunOnBeforeSend handler) {
         handlers.add(handler);
         return this;
     }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
@@ -12,12 +12,16 @@ import java.util.List;
  *      new RaygunOnBeforeSendChain()
  *          .filterWith(new RaygunRequestHeaderFilter("AUTH", "COOKIE"),
  *          .filterWith(new RaygunRequestFormFilter("password", "secret")
- *          ....
+ *      )
+ *      .beforeAll(doThisFirst)
+ *      .afterAll(doThisLast)
  * );
  */
 public class RaygunOnBeforeSendChain implements IRaygunOnBeforeSend {
 
     private List<IRaygunOnBeforeSend> handlers;
+    private IRaygunOnBeforeSend lastFilter;
+    private IRaygunOnBeforeSend firstFilter;
 
     public RaygunOnBeforeSendChain() {
         this(new ArrayList<IRaygunOnBeforeSend>());
@@ -28,19 +32,67 @@ public class RaygunOnBeforeSendChain implements IRaygunOnBeforeSend {
     }
 
     public RaygunMessage onBeforeSend(RaygunMessage message) {
+        if (firstFilter != null) {
+            firstFilter.onBeforeSend(message);
+        }
+
         for (IRaygunOnBeforeSend raygunOnBeforeSend : getHandlers()) {
             message = raygunOnBeforeSend.onBeforeSend(message);
         }
 
+        if (lastFilter != null) {
+            lastFilter.onBeforeSend(message);
+        }
+
         return message;
+    }
+
+    public RaygunOnBeforeSendChain filterWith(IRaygunOnBeforeSend handler) {
+        handlers.add(handler);
+        return this;
+    }
+
+    /**
+     * Perform a specific filter before the other filters
+     * @param firstFilter
+     * @return
+     */
+    public RaygunOnBeforeSendChain beforeAll(IRaygunOnBeforeSend firstFilter) {
+        this.firstFilter = firstFilter;
+        return this;
+    }
+
+    /**
+     * Perform a specific filter after the other filters
+     * @param lastFilter
+     * @return
+     */
+    public RaygunOnBeforeSendChain afterAll(IRaygunOnBeforeSend lastFilter) {
+        this.lastFilter = lastFilter;
+        return this;
     }
 
     public List<IRaygunOnBeforeSend> getHandlers() {
         return handlers;
     }
 
-    public RaygunOnBeforeSendChain filterWith(IRaygunOnBeforeSend handler) {
-        handlers.add(handler);
-        return this;
+    public void setHandlers(List<IRaygunOnBeforeSend> handlers) {
+        this.handlers = handlers;
+    }
+
+    public IRaygunOnBeforeSend getLastFilter() {
+        return lastFilter;
+    }
+
+    public void setLastFilter(IRaygunOnBeforeSend lastFilter) {
+        this.lastFilter = lastFilter;
+    }
+
+    public IRaygunOnBeforeSend getFirstFilter() {
+        return firstFilter;
+    }
+
+    public void setFirstFilter(IRaygunOnBeforeSend firstFilter) {
+        this.firstFilter = firstFilter;
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/AbstractRaygunRequestMapFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/AbstractRaygunRequestMapFilter.java
@@ -1,6 +1,6 @@
 package com.mindscapehq.raygun4java.core.filters;
 
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
@@ -10,7 +10,7 @@ import java.util.Map;
 /**
  * Base class to filter/redact data from Raygun request maps
  */
-public abstract class AbstractRaygunRequestMapFilter<T> implements RaygunOnBeforeSend {
+public abstract class AbstractRaygunRequestMapFilter<T> implements IRaygunOnBeforeSend {
     private final String[] keysToFilter;
     private String replacement = "[FILTERED]";
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunDuplicateErrorFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunDuplicateErrorFilter.java
@@ -1,0 +1,36 @@
+package com.mindscapehq.raygun4java.core.filters;
+
+import com.mindscapehq.raygun4java.core.IRaygunOnAfterSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+public class RaygunDuplicateErrorFilter implements IRaygunOnBeforeSend, IRaygunOnAfterSend {
+
+    private Map<Throwable, Throwable> sentErrors = new WeakHashMap<Throwable, Throwable>();
+
+    public RaygunMessage onBeforeSend(RaygunMessage message) {
+        if (message.getDetails() != null
+                && message.getDetails().getError() != null
+                && message.getDetails().getError().getThrowable() != null) {
+            if (sentErrors.containsKey(message.getDetails().getError().getThrowable())) {
+                return null;
+            }
+        }
+        return message;
+    }
+
+    public RaygunMessage onAfterSend(RaygunMessage message) {
+        if (message.getDetails() != null
+                && message.getDetails().getError() != null
+                && message.getDetails().getError().getThrowable() != null) {
+            Throwable throwable = message.getDetails().getError().getThrowable();
+            if (!sentErrors.containsKey(throwable)) {
+                sentErrors.put(throwable, throwable);
+            }
+        }
+        return message;
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunExcludeRequestFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunExcludeRequestFilter.java
@@ -1,13 +1,13 @@
 package com.mindscapehq.raygun4java.core.filters;
 
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 
 /**
  * Discards the request if it matches the provided filter
  */
-public class RaygunExcludeRequestFilter implements RaygunOnBeforeSend {
+public class RaygunExcludeRequestFilter implements IRaygunOnBeforeSend {
 
     private Filter filter;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunStripWrappedExceptionFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/RaygunStripWrappedExceptionFilter.java
@@ -1,10 +1,10 @@
 package com.mindscapehq.raygun4java.core.filters;
 
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.messages.RaygunErrorMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
-public class RaygunStripWrappedExceptionFilter implements RaygunOnBeforeSend {
+public class RaygunStripWrappedExceptionFilter implements IRaygunOnBeforeSend {
 
     private Class[] stripClasses;
 
@@ -17,10 +17,10 @@ public class RaygunStripWrappedExceptionFilter implements RaygunOnBeforeSend {
         if(message.getDetails() != null
                 && message.getDetails().getError() != null
                 && message.getDetails().getError().getInnerError() != null
-                && message.getDetails().getError().getThrowableClass() != null) {
+                && message.getDetails().getError().getThrowable() != null) {
 
             for (Class stripClass : stripClasses) {
-                if (stripClass.isAssignableFrom(message.getDetails().getError().getThrowableClass())) {
+                if (stripClass.isAssignableFrom(message.getDetails().getError().getThrowable().getClass())) {
                     RaygunErrorMessage innerError = message.getDetails().getError().getInnerError();
                     message.getDetails().setError(innerError);
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunErrorMessage.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunErrorMessage.java
@@ -1,15 +1,17 @@
 package com.mindscapehq.raygun4java.core.messages;
 
+import java.lang.ref.WeakReference;
+
 public class RaygunErrorMessage {
 
-    private transient Class throwableClass;
+    private transient WeakReference<Throwable> throwable;
     private RaygunErrorMessage innerError;
     private String message;
     private String className;
     private RaygunErrorStackTraceLineMessage[] stackTrace;
 
     public RaygunErrorMessage(Throwable throwable) {
-        throwableClass = throwable.getClass();
+        this.throwable = new WeakReference<Throwable>(throwable);
         message = throwable.getClass().getSimpleName();
         String throwableMessage = throwable.getMessage();
         if (throwableMessage != null) {
@@ -18,7 +20,7 @@ public class RaygunErrorMessage {
         className = throwable.getClass().getCanonicalName();
 
         if (throwable.getCause() != null) {
-            innerError = new RaygunErrorMessage((Exception) throwable.getCause());
+            innerError = new RaygunErrorMessage(throwable.getCause());
         }
 
         StackTraceElement[] ste = throwable.getStackTrace();
@@ -61,7 +63,10 @@ public class RaygunErrorMessage {
         this.stackTrace = stackTrace;
     }
 
-    public Class getThrowableClass() {
-        return throwableClass;
+    public Throwable getThrowable() {
+        if(throwable != null && throwable.get() != null) {
+            return throwable.get();
+        }
+        return null;
     }
 }

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientFactoryTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientFactoryTest.java
@@ -1,5 +1,6 @@
 package com.mindscapehq.raygun4java.core;
 
+import com.mindscapehq.raygun4java.core.filters.RaygunDuplicateErrorFilter;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -39,13 +40,22 @@ public class RaygunClientFactoryTest {
     }
 
     @Test
+    public void shouldConstructFactoryWithDuplicateErrorHandler() {
+        IRaygunClientFactory factory = new RaygunClientFactory("apiKey");
+
+        assertTrue(factory.getRaygunOnBeforeSendChain().getLastFilter() instanceof RaygunDuplicateErrorFilter);
+        assertEquals(factory.getRaygunOnAfterSendChain().getHandlers().get(0), factory.getRaygunOnBeforeSendChain().getLastFilter());
+    }
+
     @Test
     public void shouldConstructFactoryWithOnBeforeSendHandler() {
         IRaygunOnBeforeSend handler = mock(IRaygunOnBeforeSend.class);
 
         IRaygunClientFactory factory = new RaygunClientFactory("apiKey").withBeforeSend(handler);
 
-        assertEquals(factory.getRaygunOnBeforeSendChain().getHandlers().get(1), handler);
+        assertEquals(factory.getRaygunOnBeforeSendChain().getHandlers().get(0), handler);
+
+        assertEquals(factory.newClient().onBeforeSend, factory.getRaygunOnBeforeSendChain());
     }
 
     @Test
@@ -54,6 +64,8 @@ public class RaygunClientFactoryTest {
 
         IRaygunClientFactory factory = new RaygunClientFactory("apiKey").withAfterSend(handler);
 
-        assertEquals(factory.getRaygunOnBeforeSendChain().getHandlers().get(1), handler);
+        assertEquals(factory.getRaygunOnAfterSendChain().getHandlers().get(1), handler);
+
+        assertEquals(factory.newClient().onAfterSend, factory.getRaygunOnAfterSendChain());
     }
 }

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientFactoryTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientFactoryTest.java
@@ -3,6 +3,7 @@ package com.mindscapehq.raygun4java.core;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class RaygunClientFactoryTest {
@@ -29,7 +30,7 @@ public class RaygunClientFactoryTest {
 
     @Test
     public void shouldConstructFactoryWithSuppliedVersion() {
-        RaygunClientFactory factory = new RaygunClientFactory("apiKey", "1.2.3");
+        IRaygunClientFactory factory = new RaygunClientFactory("apiKey").withVersion("1.2.3");
 
         RaygunClient client = factory.newClient();
 
@@ -38,12 +39,21 @@ public class RaygunClientFactoryTest {
     }
 
     @Test
+    @Test
     public void shouldConstructFactoryWithOnBeforeSendHandler() {
-        RaygunOnBeforeSend handler = mock(RaygunOnBeforeSend.class);
+        IRaygunOnBeforeSend handler = mock(IRaygunOnBeforeSend.class);
+
         IRaygunClientFactory factory = new RaygunClientFactory("apiKey").withBeforeSend(handler);
 
-        RaygunClient client = factory.newClient();
+        assertEquals(factory.getRaygunOnBeforeSendChain().getHandlers().get(1), handler);
+    }
 
-        assertEquals(client.onBeforeSend, handler);
+    @Test
+    public void shouldConstructFactoryWithOnAfterSendHandler() {
+        IRaygunOnAfterSend handler = mock(IRaygunOnAfterSend.class);
+
+        IRaygunClientFactory factory = new RaygunClientFactory("apiKey").withAfterSend(handler);
+
+        assertEquals(factory.getRaygunOnBeforeSendChain().getHandlers().get(1), handler);
     }
 }

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -81,6 +81,17 @@ public class RaygunClientTest {
     }
 
     @Test
+    public void post_SendWithOnAfterSend_Returns202() throws IOException {
+        IRaygunOnAfterSend handler = mock(IRaygunOnAfterSend.class);
+        RaygunMessage message = new RaygunMessage();
+        this.raygunClient.setOnAfterSend(handler);
+
+        assertEquals(202, this.raygunClient.send(new Exception()));
+
+        verify(handler).onAfterSend((RaygunMessage) anyObject());
+    }
+
+    @Test
     public void raygunMessageDetailsGetVersion_FromClass_ReturnsClassManifestVersion() {
         this.raygunClient.setVersionFrom(org.apache.commons.io.IOUtils.class);
 

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -70,7 +70,7 @@ public class RaygunClientTest {
 
     @Test
     public void post_SendWithOnBeforeSend_Returns202() throws IOException {
-        RaygunOnBeforeSend handler = mock(RaygunOnBeforeSend.class);
+        IRaygunOnBeforeSend handler = mock(IRaygunOnBeforeSend.class);
         RaygunMessage message = new RaygunMessage();
         when(handler.onBeforeSend((RaygunMessage) anyObject())).thenReturn(message);
         this.raygunClient.setOnBeforeSend(handler);

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/filters/RaygunDuplicateErrorFilterTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/filters/RaygunDuplicateErrorFilterTest.java
@@ -1,0 +1,43 @@
+package com.mindscapehq.raygun4java.core.filters;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunErrorMessage;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessageDetails;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RaygunDuplicateErrorFilterTest {
+
+    @Test
+    public void shouldFilterSameException() {
+
+        RaygunDuplicateErrorFilter filter = new RaygunDuplicateErrorFilter();
+        Exception exception = new Exception();
+
+        RaygunMessage message = new RaygunMessage();
+        RaygunMessageDetails details = new RaygunMessageDetails();
+        RaygunErrorMessage error = new RaygunErrorMessage(exception);
+        details.setError(error);
+        message.setDetails(details);
+
+        assertEquals(message, filter.onBeforeSend(message)); // not filtered first time
+        filter.onAfterSend(message);
+
+        message = new RaygunMessage();
+        details = new RaygunMessageDetails();
+        error = new RaygunErrorMessage(exception);
+        details.setError(error);
+        message.setDetails(details);
+
+        assertNull(filter.onBeforeSend(message)); // filtered second time
+
+        message = new RaygunMessage();
+        details = new RaygunMessageDetails();
+        error = new RaygunErrorMessage(new Exception()); // different exception
+        details.setError(error);
+        message.setDetails(details);
+        assertEquals(message, filter.onBeforeSend(message)); // not filtered
+    }
+
+}

--- a/sampleapp/src/main/java/com/mindscapehq/raygun4java/sampleapp/SampleApp.java
+++ b/sampleapp/src/main/java/com/mindscapehq/raygun4java/sampleapp/SampleApp.java
@@ -1,7 +1,7 @@
 package com.mindscapehq.raygun4java.sampleapp;
 
 import com.mindscapehq.raygun4java.core.RaygunClient;
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.messages.RaygunIdentifier;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
@@ -21,7 +21,7 @@ public class SampleApp {
     }
 }
 
-class BeforeSendImplementation implements RaygunOnBeforeSend {
+class BeforeSendImplementation implements IRaygunOnBeforeSend {
     @Override
     public RaygunMessage onBeforeSend(RaygunMessage message) {
         //String errorMessage = message.getDetails().getError().getMessage();

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -1,7 +1,6 @@
 package com.mindscapehq.raygun4java.webprovider;
 
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSendChain;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.filters.RaygunExcludeLocalRequestFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunRequestCookieFilter;
 import com.mindscapehq.raygun4java.core.filters.RaygunRequestFormFilter;
@@ -21,15 +20,11 @@ import javax.servlet.ServletContext;
  *                 .getClient(request);
  */
 public class DefaultRaygunServletClientFactory extends RaygunServletClientFactory {
-    private final RaygunOnBeforeSendChain chain;
-
     public DefaultRaygunServletClientFactory(String apiKey, ServletContext context) {
         super(apiKey, context);
-        chain = new RaygunOnBeforeSendChain();
-        withBeforeSend(chain);
     }
 
-    public DefaultRaygunServletClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend) {
+    public DefaultRaygunServletClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend) {
         super.withBeforeSend(onBeforeSend);
         return this;
     }
@@ -69,7 +64,7 @@ public class DefaultRaygunServletClientFactory extends RaygunServletClientFactor
         return this;
     }
 
-        chain.getHandlers().add(raygunOnBeforeSend);
     public void addFilter(IRaygunOnBeforeSend raygunOnBeforeSend) {
+        getRaygunOnBeforeSendChain().filterWith(raygunOnBeforeSend);
     }
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -17,7 +17,7 @@ import javax.servlet.ServletContext;
  *                 .withRequestFormFilters("form1", "form2")
  *                 .withRequestHeaderFilters("header1", "header2")
  *                 .withRequestQueryStringFilters("queryParam1", "queryParam2")
- *                 .getClient(request);
+ *                 .newClient(request);
  */
 public class DefaultRaygunServletClientFactory extends RaygunServletClientFactory {
     public DefaultRaygunServletClientFactory(String apiKey, ServletContext context) {

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -69,7 +69,7 @@ public class DefaultRaygunServletClientFactory extends RaygunServletClientFactor
         return this;
     }
 
-    public void addFilter(RaygunOnBeforeSend raygunOnBeforeSend) {
         chain.getHandlers().add(raygunOnBeforeSend);
+    public void addFilter(IRaygunOnBeforeSend raygunOnBeforeSend) {
     }
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
@@ -1,7 +1,10 @@
 package com.mindscapehq.raygun4java.webprovider;
 
 import com.mindscapehq.raygun4java.core.IRaygunClientFactory;
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnAfterSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.RaygunOnAfterSendChain;
+import com.mindscapehq.raygun4java.core.RaygunOnBeforeSendChain;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -9,5 +12,10 @@ import javax.servlet.http.HttpServletRequest;
 public interface IRaygunServletClientFactory extends IRaygunClientFactory {
     RaygunServletClient getClient(HttpServletRequest request);
     IRaygunServletClientFactory withVersionFrom(ServletContext context);
+
     IRaygunServletClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend);
+    IRaygunServletClientFactory withAfterSend(IRaygunOnAfterSend onAfterSend);
+
+    RaygunOnBeforeSendChain getRaygunOnBeforeSendChain();
+    RaygunOnAfterSendChain getRaygunOnAfterSendChain();
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
@@ -8,6 +8,6 @@ import javax.servlet.http.HttpServletRequest;
 
 public interface IRaygunServletClientFactory extends IRaygunClientFactory {
     RaygunServletClient getClient(HttpServletRequest request);
-    IRaygunServletClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend);
     IRaygunServletClientFactory withVersionFrom(ServletContext context);
+    IRaygunServletClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend);
 }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/IRaygunServletClientFactory.java
@@ -10,7 +10,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
 public interface IRaygunServletClientFactory extends IRaygunClientFactory {
-    RaygunServletClient getClient(HttpServletRequest request);
+    RaygunServletClient newClient(HttpServletRequest request);
     IRaygunServletClientFactory withVersionFrom(ServletContext context);
 
     IRaygunServletClientFactory withBeforeSend(IRaygunOnBeforeSend onBeforeSend);

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunClient.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunClient.java
@@ -47,7 +47,7 @@ public class RaygunClient {
         if (factory == null) {
             throw new RuntimeException("RaygunClient is not initialized. Call RaygunClient.Initialize()");
         }
-        client.set(factory.getClient(request));
+        client.set(factory.newClient(request));
     }
 
     /**

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClient.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClient.java
@@ -1,7 +1,7 @@
 package com.mindscapehq.raygun4java.webprovider;
 
 import com.mindscapehq.raygun4java.core.RaygunClient;
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
 import javax.servlet.http.HttpServletRequest;
@@ -89,7 +89,7 @@ public class RaygunServletClient extends RaygunClient {
         return apiKey;
     }
 
-    public RaygunOnBeforeSend getOnBeforeSend() {
+    public IRaygunOnBeforeSend getOnBeforeSend() {
         return onBeforeSend;
     }
 

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
@@ -2,8 +2,8 @@ package com.mindscapehq.raygun4java.webprovider;
 
 import com.mindscapehq.raygun4java.core.IRaygunClientFactory;
 import com.mindscapehq.raygun4java.core.IRaygunMessageBuilderFactory;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.RaygunClient;
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -67,8 +67,8 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
      * @param onBeforeSend
      * @return factory
      */
-    public IRaygunServletClientFactory withBeforeSend(RaygunOnBeforeSend onBeforeSend) {
         this.onBeforeSend = onBeforeSend;
+    public IRaygunServletClientFactory withAfterSend(IRaygunOnAfterSend onAfterSend) {
         return this;
     }
 

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletMessageBuilder.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletMessageBuilder.java
@@ -46,9 +46,11 @@ public class RaygunServletMessageBuilder extends RaygunMessageBuilder implements
 
     public String getVersion(ServletContext context) {
         try {
-            URL resource = context.getResource("/META-INF/MANIFEST.MF");
-            if (resource != null) {
-                return readVersionFromManifest(resource.openStream());
+            if (context != null) {
+                URL resource = context.getResource("/META-INF/MANIFEST.MF");
+                if (resource != null) {
+                    return readVersionFromManifest(resource.openStream());
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletFilterFacadeTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletFilterFacadeTest.java
@@ -23,7 +23,7 @@ public class DefaultRaygunServletFilterFacadeTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         RaygunClient.initialize(factory);
-        when(factory.getClient(request)).thenReturn(client);
+        when(factory.newClient(request)).thenReturn(client);
     }
 
     @After

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
@@ -1,6 +1,6 @@
 package com.mindscapehq.raygun4java.webprovider;
 
-import com.mindscapehq.raygun4java.core.RaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -34,7 +34,7 @@ public class RaygunServletClientFactoryTest {
     @Test
     public void shouldInitializeWithOnBeforeSend() {
 
-        RaygunOnBeforeSend handler = mock(RaygunOnBeforeSend.class);
+        IRaygunOnBeforeSend handler = mock(IRaygunOnBeforeSend.class);
         IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withBeforeSend(handler);
 
         RaygunServletClient client = factory.getClient(null);

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
@@ -1,10 +1,16 @@
 package com.mindscapehq.raygun4java.webprovider;
 
+import com.mindscapehq.raygun4java.core.IRaygunClientFactory;
+import com.mindscapehq.raygun4java.core.IRaygunOnAfterSend;
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.RaygunClientFactory;
+import com.mindscapehq.raygun4java.core.filters.RaygunDuplicateErrorFilter;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class RaygunServletClientFactoryTest {
@@ -15,7 +21,7 @@ public class RaygunServletClientFactoryTest {
     public void shouldInitializeWithVersion() {
         IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withVersion("thisVersion");
 
-        RaygunServletClient client = factory.getClient(null);
+        RaygunServletClient client = factory.newClient(null);
 
         assertThat(client.getVersion(), is("thisVersion"));
         assertThat(client.getApiKey(), is(apiKey));
@@ -25,20 +31,39 @@ public class RaygunServletClientFactoryTest {
     public void shouldInitializeWithVersionFromClass() {
         IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withVersionFrom(org.apache.commons.io.IOUtils.class);
 
-        RaygunServletClient client = factory.getClient(null);
+        RaygunServletClient client = factory.newClient(null);
 
         assertThat(client.getVersion(), is("2.5"));
         assertThat(client.getApiKey(), is(apiKey));
     }
 
     @Test
-    public void shouldInitializeWithOnBeforeSend() {
+    public void shouldConstructFactoryWithDuplicateErrorHandler() {
+        IRaygunClientFactory factory = new RaygunClientFactory("apiKey");
 
+        assertTrue(factory.getRaygunOnBeforeSendChain().getLastFilter() instanceof RaygunDuplicateErrorFilter);
+        assertEquals(factory.getRaygunOnAfterSendChain().getHandlers().get(0), factory.getRaygunOnBeforeSendChain().getLastFilter());
+    }
+
+    @Test
+    public void shouldConstructFactoryWithOnBeforeSendHandler() {
         IRaygunOnBeforeSend handler = mock(IRaygunOnBeforeSend.class);
-        IRaygunServletClientFactory factory = new RaygunServletClientFactory(apiKey).withBeforeSend(handler);
 
-        RaygunServletClient client = factory.getClient(null);
+        IRaygunServletClientFactory factory = new RaygunServletClientFactory("apiKey").withBeforeSend(handler);
 
-        assertThat(client.getOnBeforeSend(), is(handler));
+        assertEquals(factory.getRaygunOnBeforeSendChain().getHandlers().get(0), handler);
+
+        assertEquals(factory.newClient(null).getOnBeforeSend(), factory.getRaygunOnBeforeSendChain());
+    }
+
+    @Test
+    public void shouldConstructFactoryWithOnAfterSendHandler() {
+        IRaygunOnAfterSend handler = mock(IRaygunOnAfterSend.class);
+
+        IRaygunServletClientFactory factory = new RaygunServletClientFactory("apiKey").withAfterSend(handler);
+
+        assertEquals(factory.getRaygunOnAfterSendChain().getHandlers().get(1), handler);
+
+        assertEquals(factory.newClient(null).getOnAfterSend(), factory.getRaygunOnAfterSendChain());
     }
 }

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
@@ -178,7 +178,7 @@ public class RaygunServletClientTest {
                 .withRequestHeaderFilters("header1", "header2")
                 .withRequestQueryStringFilters("queryParam1", "queryParam2")
                 .withRequestCookieFilters("cookie2")
-                .getClient(request);
+                .newClient(request);
         raygunClient.setRaygunConnection(raygunConnectionMock);
 
         int send = raygunClient.send(new Exception());


### PR DESCRIPTION
This PR adds support for detecting already send errors, so that a multiply handled exception in the same `RaygunClient` is only sent once.

note: this modifies the chain handler to add hooks to execute handers before and after all other handlers - this is so that the detecting of duplication can happen as the last handler before the error is sent

changes:
* Raygun factories now default to using the event chain
* Adds `OnAfterSend` handlers
* Adds a `.beforeAll()` and `.afterAll()` to chain
* Adds `RaygunDuplicateErrorFilter`
