### PR TITLE
Move tags and userdata to factory and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,8 @@ The pom.xml will need to contain something like:
 	...
     <dependency>
     	<groupId>com.mindscapehq</groupId>
-    	<artifactId>raygun4java</artifactId>
-    	<type>pom</type>
-    	<version>2.2.1</version>
-    </dependency>
-    <dependency>
-    	<groupId>com.mindscapehq</groupId>
     	<artifactId>core</artifactId>
-    	<version>2.2.1</version>
+    	<version>3.0.0</version>
     </dependency>
 </dependencies>
 ```
@@ -47,7 +41,7 @@ If you're using servlets, JSPs or similar, you'll need to also add:
 <dependency>
     <groupId>com.mindscapehq</groupId>
     <artifactId>webprovider</artifactId>
-    <version>2.2.1</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 
@@ -84,12 +78,15 @@ IRaygunClientFactory factory = new RaygunClientFactory("YOUR_API_KEY")
     .withVersion("1.2.3")
     .withMessageBuilder(myCustomizedMessageBuilder)
     .withBeforeSend(myCustomOnBeforeSendHandler);
+    .withTag("beta")
+    .withData("prod", false)
 ```
 
 - Add meta data
 ```java
 RaygunClient client = factory.newClient();
 client.setUser(user);
+client.tag("blue").withData("usersegment", "developer")
 client.recordBreadcrumb("i was here")
 ```
 
@@ -341,24 +338,24 @@ The previous method, SetUser(string) has been deprecated as of 1.5.0 and removed
 
 ### Custom user data and tags
 
-To attach custom data or tags, use these overloads on Send:
-
+You can attatch custom data or tags on the factory so that all error will be tagged ie:
 ```java
-RaygunClient client;
-Exception exception;
-
-ArrayList tags = new ArrayList<String>();
-tags.add("tag1");
-
-Map<string, int> userCustomData = new HashMap<string, int>();
-userCustomData.put("data", 1);
-
-client.send(exception, tags);
-// or
-client.send(exception, tags, userCustomData);
+factory
+    .withTag("tag1")
+    .withTag("tag2")
+    .withData("data1", 1)
+    .withData("data2", 2);
 ```
 
-Tags can be null if you only wish to transmit custom data. Send calls can take these objects inside a catch block (if you want one instance to contain specific local variables), or in a global exception handler ()if you want every exception to contain a set of tags/custom data, initialized on construction).
+or attach to the client:
+
+```java
+client
+    .withTag("tag1")
+    .withTag("tag2")
+    .withData("data1", 1)
+    .withData("data2", 2);
+```
 
 ### Breadcrumbs
 You can set breadcrumbs to record the flow through your application. Breadcrumbs are set against the current `RaygunClient`.

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
@@ -8,6 +8,8 @@ public interface IRaygunClientFactory {
     IRaygunClientFactory withBeforeSend(IRaygunSendEventFactory<IRaygunOnBeforeSend> onBeforeSend);
     IRaygunClientFactory withAfterSend(IRaygunSendEventFactory<IRaygunOnAfterSend> onAfterSend);
     IRaygunClientFactory withBreadcrumbLocations();
+    IRaygunClientFactory withTag(String tag);
+    IRaygunClientFactory withData(Object key, Object value);
     RaygunClient newClient();
     AbstractRaygunSendEventChainFactory getRaygunOnBeforeSendChainFactory();
     AbstractRaygunSendEventChainFactory getRaygunOnAfterSendChainFactory();

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
@@ -2,6 +2,11 @@ package com.mindscapehq.raygun4java.core;
 
 import com.mindscapehq.raygun4java.core.filters.RaygunDuplicateErrorFilterFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 /**
  * An out-of-the-box RaygunClient factory.
  *
@@ -22,6 +27,8 @@ public class RaygunClientFactory implements IRaygunClientFactory {
     private String apiKey;
     private AbstractRaygunSendEventChainFactory<IRaygunOnBeforeSend> onBeforeSendChainFactory;
     private AbstractRaygunSendEventChainFactory<IRaygunOnAfterSend> onAfterSendChainFactory;
+    protected List<String> tags;
+    protected Map data;
     private RaygunClient client;
     private boolean shouldProcessBreadcrumbLocations = false;
     private IRaygunMessageBuilderFactory raygunMessageBuilderFactory = new IRaygunMessageBuilderFactory() {
@@ -37,6 +44,9 @@ public class RaygunClientFactory implements IRaygunClientFactory {
     public RaygunClientFactory(String apiKey) {
         this.apiKey = apiKey;
         version = new RaygunMessageBuilder().setVersion(null).build().getDetails().getVersion();
+
+        tags = new ArrayList<String>();
+        data = new WeakHashMap();
 
         RaygunDuplicateErrorFilterFactory duplicateErrorRecordFilterFactory = new RaygunDuplicateErrorFilterFactory();
 
@@ -79,6 +89,9 @@ public class RaygunClientFactory implements IRaygunClientFactory {
         client.setOnAfterSend(onAfterSendChainFactory.create());
         client.string = version;
         client.shouldProcessBreadcrumbLocation(shouldProcessBreadcrumbLocations);
+        client.setTags(new ArrayList<String>(tags));
+        client.setData(new WeakHashMap(data));
+
         return client;
     }
 
@@ -115,6 +128,32 @@ public class RaygunClientFactory implements IRaygunClientFactory {
      */
     public IRaygunClientFactory withBreadcrumbLocations() {
         this.shouldProcessBreadcrumbLocations = true;
+        return this;
+    }
+
+    public IRaygunClientFactory withTag(String tag) {
+        tags.add(tag);
+        return this;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Map<?, ?> getData() {
+        return data;
+    }
+
+    public void setData(Map<?, ?> data) {
+        this.data = data;
+    }
+
+    public IRaygunClientFactory withData(Object key, Object value) {
+        data.put(key, value);
         return this;
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/filters/AbstractRaygunRequestMapFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/filters/AbstractRaygunRequestMapFilter.java
@@ -9,7 +9,7 @@ import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 import java.util.Map;
 
 /**
- * Base class to filter/redact data from Raygun request maps
+ * Base class to filter/redact withData from Raygun request maps
  */
 public abstract class AbstractRaygunRequestMapFilter<T> implements IRaygunOnBeforeSend, IRaygunSendEventFactory {
     private final String[] keysToFilter;

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunIdentifier.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/messages/RaygunIdentifier.java
@@ -29,7 +29,7 @@ public class RaygunIdentifier {
     }
 
     /**
-     * @param isAnonymous Whether this user data represents an anonymous user
+     * @param isAnonymous Whether this user withData represents an anonymous user
      * @return this
      */
     public RaygunIdentifier withAnonymous(Boolean isAnonymous) {

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +49,7 @@ public class RaygunClientTest {
         assertThat(assertBreadcrumb.getLevel(), is(RaygunBreadcrumbLevel.INFO));
         assertThat(assertBreadcrumb.getClassName(), is("com.mindscapehq.raygun4java.core.RaygunClientTest"));
         assertThat(assertBreadcrumb.getMethodName(), is("shouldAddBreadCrumbFromMessageWithLocation"));
-        assertThat(assertBreadcrumb.getLineNumber(), is(43));
+        assertThat(assertBreadcrumb.getLineNumber(), is(44));
     }
 
     @Test
@@ -62,7 +63,7 @@ public class RaygunClientTest {
         assertThat(assertBreadcrumb.getLevel(), is(RaygunBreadcrumbLevel.INFO));
         assertThat(assertBreadcrumb.getClassName(), is("com.mindscapehq.raygun4java.core.RaygunClientTest"));
         assertThat(assertBreadcrumb.getMethodName(), is("shouldAddBreadCrumbMessageWithLocation"));
-        assertThat(assertBreadcrumb.getLineNumber(), is(57));
+        assertThat(assertBreadcrumb.getLineNumber(), is(58));
     }
 
     //////////////////////////////
@@ -104,34 +105,42 @@ public class RaygunClientTest {
 
     @Test
     public void post_SendWithTags_Returns202() throws IOException {
-        List<?> tags = Arrays.asList("these", "are", "tags");
+        raygunClient.setTags(new ArrayList(Arrays.asList("these", "are", "tags")));
+        raygunClient.withTag("boom").withTag("bang");
 
-        assertEquals(202, raygunClient.send(new Exception(), tags));
+        assertEquals(202, raygunClient.send(new Exception()));
 
         List<?> tags1 = fromJsonStream().getDetails().getTags();
         assertThat(tags1.get(0), Is.<Object>is("these"));
         assertThat(tags1.get(1), Is.<Object>is("are"));
         assertThat(tags1.get(2), Is.<Object>is("tags"));
+        assertThat(tags1.get(3), Is.<Object>is("boom"));
+        assertThat(tags1.get(4), Is.<Object>is("bang"));
     }
 
     @Test
     public void post_SendWithCustomData_Returns202() throws IOException {
-                Map<String, String> data = new HashMap<String, String>();
+        Map<String, Object> data = new HashMap<String, Object>();
         data.put("hello", "world");
+        raygunClient.setData(data);
+        raygunClient.withData("foo", "bar");
 
-        assertEquals(202, raygunClient.send(new Exception(), null, data));
+        assertEquals(202, raygunClient.send(new Exception()));
 
         Map<?, ?> customData = fromJsonStream().getDetails().getUserCustomData();
         assertThat(customData.get("hello"), Is.<Object>is("world"));
+        assertThat(customData.get("foo"), Is.<Object>is("bar"));
     }
 
     @Test
     public void post_SendWithUserDataAndTagsCustomData_Returns202() throws IOException {
-        List<?> tags = Arrays.asList("these", "are", "tags");
-        Map<String, String> data = new HashMap<String, String>();
+        List<String> tags = Arrays.asList("these", "are", "tags");
+        Map<String, Object> data = new HashMap<String, Object>();
         data.put("hello", "world");
+        raygunClient.setTags(tags);
+        raygunClient.setData(data);
 
-        assertEquals(202, raygunClient.send(new Exception(), tags, data));
+        assertEquals(202, raygunClient.send(new Exception()));
 
         List<?> tags1 = fromJsonStream().getDetails().getTags();
         assertThat(tags1.get(0), Is.<Object>is("these"));
@@ -202,7 +211,7 @@ public class RaygunClientTest {
     }
 
     private RaygunMessage fromJson() {
-        String body = raygunClient.toJson(raygunClient.buildMessage(null, null, null));
+        String body = raygunClient.toJson(raygunClient.buildMessage(null));
         return gson.fromJson(body, RaygunMessage.class);
     }
 

--- a/playprovider/src/main/java/com/mindscapehq/raygun4java/play2/RaygunPlayClient.java
+++ b/playprovider/src/main/java/com/mindscapehq/raygun4java/play2/RaygunPlayClient.java
@@ -47,7 +47,7 @@ public class RaygunPlayClient extends RaygunClient {
 
     public int send(Throwable throwable, List<?> tags, Map<?, ?> userCustomData) {
         if (throwable != null) {
-            return post(buildServletMessage(throwable, tags, userCustomData));
+            return send(buildServletMessage(throwable, tags, userCustomData));
         }
         return -1;
     }
@@ -69,7 +69,7 @@ public class RaygunPlayClient extends RaygunClient {
     private void postAsync(final RaygunMessage message) {
         Runnable r = new Runnable() {
             public void run() {
-                post(message);
+                send(message);
             }
         };
 

--- a/sampleapp/src/main/java/com/mindscapehq/raygun4java/sampleapp/SampleApp.java
+++ b/sampleapp/src/main/java/com/mindscapehq/raygun4java/sampleapp/SampleApp.java
@@ -9,9 +9,6 @@ import com.mindscapehq.raygun4java.core.RaygunClientFactory;
 import com.mindscapehq.raygun4java.core.messages.RaygunIdentifier;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -56,17 +53,10 @@ public class SampleApp {
                     // lets handle this exception - this should appear in the raygun console
                     Map<String, String> customData = new HashMap<String, String>();
                     customData.put("thread id", "" + Thread.currentThread().getId());
-                    MyExceptionHandler.getClient().send(
-                            exceptionToThrowLater,
-                            Arrays.asList("thrown from thread", "no user data"),
-                            customData
-                            );
+                    MyExceptionHandler.getClient().withTag("thrown from thread").withTag("no user withData").withData("thread id", "" + Thread.currentThread().getId()).send(exceptionToThrowLater);
 
                     MyExceptionHandler.getClient().recordBreadcrumb("This should not appear because we're sending the same exception on the same thread");
-                    MyExceptionHandler.getClient().send(
-                            exceptionToThrowLater,
-                            Collections.singletonList("should not appear in console")
-                    );
+                    MyExceptionHandler.getClient().withTag("should not appear in console").send(exceptionToThrowLater);
                 }
             }
         }).start();
@@ -123,11 +113,7 @@ class MyExceptionHandler implements Thread.UncaughtExceptionHandler {
     }
 
     public void uncaughtException(Thread t, Throwable e) {
-
-        ArrayList<Object> tags = new ArrayList<Object>();
-        tags.add("thrown from unhandled exception handler");
-
-        getClient().send(e, tags);
+        getClient().withTag("thrown from unhandled exception handler").send(e);
     }
 }
 

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClient.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClient.java
@@ -6,8 +6,6 @@ import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 
@@ -24,45 +22,29 @@ public class RaygunServletClient extends RaygunClient {
     }
 
     public int send(Throwable throwable) {
-        return send(throwable, null, null);
-    }
-
-    public int send(Throwable throwable, List<?> tags) {
-        return send(throwable, tags, null);
-    }
-
-    public int send(Throwable throwable, List<?> tags, Map<?, ?> userCustomData) {
         if (throwable != null) {
-            return post(buildServletMessage(throwable, tags, userCustomData));
+            return send(buildServletMessage(throwable));
         }
         return -1;
     }
 
     public void sendAsync(Throwable throwable) {
-        sendAsync(throwable, null, null);
-    }
-
-    public void sendAsync(Throwable throwable, List<?> tags) {
-        sendAsync(throwable, tags, null);
-    }
-
-    public void sendAsync(Throwable throwable, List<?> tags, Map<?, ?> userCustomData) {
         if (throwable != null) {
-            postAsync(buildServletMessage(throwable, tags, userCustomData));
+            sendAsync(buildServletMessage(throwable));
         }
     }
 
-    private void postAsync(final RaygunMessage message) {
+    private void sendAsync(final RaygunMessage message) {
         Runnable r = new Runnable() {
             public void run() {
-                post(message);
+                send(message);
             }
         };
 
         Executors.newSingleThreadExecutor().submit(r);
     }
 
-    private RaygunMessage buildServletMessage(Throwable throwable, List<?> tags, Map<?, ?> userCustomData) {
+    private RaygunMessage buildServletMessage(Throwable throwable) {
         try {
             return RaygunServletMessageBuilder.New()
                     .setRequestDetails(request, response)
@@ -73,7 +55,7 @@ public class RaygunServletClient extends RaygunClient {
                     .setVersion(string)
                     .setUser(user)
                     .setTags(tags)
-                    .setUserCustomData(userCustomData)
+                    .setUserCustomData(data)
                     .build();
         } catch (Exception e) {
             Logger.getLogger("Raygun4Java").warning("Failed to build RaygunMessage: " + e.getMessage());

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
@@ -13,6 +13,10 @@ import com.mindscapehq.raygun4java.core.filters.RaygunDuplicateErrorFilterFactor
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * An out-of-the-box RaygunClient factory that can extract the application version from the .WAR file /META-INF/MANIFEST.MF
@@ -24,6 +28,8 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
     private String apiKey;
     private AbstractRaygunSendEventChainFactory<IRaygunOnBeforeSend> onBeforeSendChainFactory;
     private AbstractRaygunSendEventChainFactory<IRaygunOnAfterSend> onAfterSendChainFactory;
+    protected List<String> tags;
+    protected Map data;
     private RaygunClient client;
     private String version;
     private boolean shouldProcessBreadcrumbLocations = false;
@@ -36,6 +42,9 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
     public RaygunServletClientFactory(String apiKey, ServletContext context) {
         this.apiKey = apiKey;
         this.version = new RaygunServletMessageBuilder().getVersion(context);
+
+        tags = new ArrayList<String>();
+        data = new WeakHashMap();
 
         RaygunDuplicateErrorFilterFactory duplicateErrorRecordFilterFactory = new RaygunDuplicateErrorFilterFactory();
 
@@ -104,6 +113,32 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
 
     public RaygunClient newClient() {
         throw new IllegalStateException("newClient() is not valid for RaygunServletFactory; use newClient(request)");
+    }
+
+    public IRaygunClientFactory withTag(String tag) {
+        tags.add(tag);
+        return this;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Map<?, ?> getData() {
+        return data;
+    }
+
+    public void setData(Map<?, ?> data) {
+        this.data = data;
+    }
+
+    public IRaygunClientFactory withData(Object key, Object value) {
+        data.put(key, value);
+        return this;
     }
 
     /**

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientTest.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.mindscapehq.raygun4java.core.RaygunConnection;
 import com.mindscapehq.raygun4java.core.messages.RaygunIdentifier;
-import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessageDetails;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 import org.junit.Before;
@@ -96,7 +95,9 @@ public class RaygunServletClientTest {
     public void send_WithTags_Returns202() throws MalformedURLException, IOException {
         List<String> tags = new ArrayList<String>();
         tags.add("test");
-        assertEquals(202, raygunClient.send(new Exception(), tags));
+        raygunClient.setTags(tags);
+        raygunClient.withTag("withTag");
+        assertEquals(202, raygunClient.send(new Exception()));
     }
 
     @Test
@@ -105,7 +106,8 @@ public class RaygunServletClientTest {
         tags.add("a_tag");
         Map<Integer, String> customData = new HashMap<Integer, String>();
         customData.put(0, "zero");
-        assertEquals(202, raygunClient.send(new Exception(), tags, customData));
+        raygunClient.withTag("a_tag").withData(0, "zero");
+        assertEquals(202, raygunClient.send(new Exception()));
     }
 
     @Test
@@ -216,7 +218,7 @@ public class RaygunServletClientTest {
     }
 
     private RaygunServletMessage fromJson() {
-        String body = raygunClient.toJson(raygunClient.buildMessage(null, null, null));
+        String body = raygunClient.toJson(raygunClient.buildMessage(null));
         return gson.fromJson(body, RaygunServletMessage.class);
     }
 


### PR DESCRIPTION
This PR adds tags and user data to the `RaygunClientFactory` so that all clients can receive the same tags.
It also adds tags and user data to the `RaygunClient` so that instances can receive the special tags.
It removes the tags and data from the `send()` functions