### PR TITLE
Adds Offline support

### DIFF
--- a/core/src/main/java/com/mindscapehq/raygun4java/core/AbstractRaygunOnSendEventChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/AbstractRaygunOnSendEventChain.java
@@ -12,19 +12,20 @@ import java.util.List;
  * Instances are not shared between RaygunClient instances
  *
  * @param <T> either IRaygunOnBeforeSend or IRaygunOnAfterSend
+ * @param <M> RaygunMessage or String
  */
-public abstract class AbstractRaygunOnSendEventChain<T extends IRaygunSentEvent> {
+public abstract class AbstractRaygunOnSendEventChain<T extends IRaygunSentEvent, M> {
     private List<T> handlers;
 
     public AbstractRaygunOnSendEventChain(List<T> handlers) {
         this.handlers = handlers;
     }
 
-    public abstract RaygunMessage handle(T handler, RaygunMessage message);
+    public abstract M handle(RaygunClient client, T handler, M message);
 
-    public RaygunMessage handle(RaygunMessage message) {
+    public M handle(RaygunClient client, M message) {
         for (T handler : handlers) {
-            message = handle(handler, message);
+            message = handle(client, handler, message);
             if (message == null) {
                 return null;
             }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunClientFactory.java
@@ -7,10 +7,14 @@ public interface IRaygunClientFactory {
     IRaygunClientFactory withMessageBuilder(IRaygunMessageBuilderFactory messageBuilderFactory);
     IRaygunClientFactory withBeforeSend(IRaygunSendEventFactory<IRaygunOnBeforeSend> onBeforeSend);
     IRaygunClientFactory withAfterSend(IRaygunSendEventFactory<IRaygunOnAfterSend> onAfterSend);
+    IRaygunClientFactory withFailedSend(IRaygunSendEventFactory<IRaygunOnFailedSend> onFailedSend);
+    IRaygunClientFactory withOfflineStorage();
+    IRaygunClientFactory withOfflineStorage(String storageDir);
     IRaygunClientFactory withBreadcrumbLocations();
     IRaygunClientFactory withTag(String tag);
     IRaygunClientFactory withData(Object key, Object value);
     RaygunClient newClient();
     AbstractRaygunSendEventChainFactory getRaygunOnBeforeSendChainFactory();
     AbstractRaygunSendEventChainFactory getRaygunOnAfterSendChainFactory();
+    AbstractRaygunSendEventChainFactory getRaygunOnFailedSendChainFactory();
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnAfterSend.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnAfterSend.java
@@ -3,5 +3,5 @@ package com.mindscapehq.raygun4java.core;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
 public interface IRaygunOnAfterSend extends IRaygunSentEvent {
-    RaygunMessage onAfterSend(RaygunMessage message);
+    RaygunMessage onAfterSend(RaygunClient client, RaygunMessage message);
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnBeforeSend.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnBeforeSend.java
@@ -3,5 +3,5 @@ package com.mindscapehq.raygun4java.core;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
 public interface IRaygunOnBeforeSend extends IRaygunSentEvent {
-    RaygunMessage onBeforeSend(RaygunMessage message);
+    RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message);
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnFailedSend.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnFailedSend.java
@@ -1,0 +1,5 @@
+package com.mindscapehq.raygun4java.core;
+
+public interface IRaygunOnFailedSend {
+    void handle(String jsonPayload, Exception e);
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnFailedSend.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/IRaygunOnFailedSend.java
@@ -1,5 +1,5 @@
 package com.mindscapehq.raygun4java.core;
 
-public interface IRaygunOnFailedSend {
-    void handle(String jsonPayload, Exception e);
+public interface IRaygunOnFailedSend extends IRaygunSentEvent {
+    String onFailedSend(RaygunClient client, String jsonPayload);
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -109,7 +109,7 @@ public class RaygunClient {
         try {
             if (validateApiKey()) {
                 if (onBeforeSend != null) {
-                    raygunMessage = onBeforeSend.onBeforeSend(raygunMessage);
+                    raygunMessage = onBeforeSend.onBeforeSend(this, raygunMessage);
 
                     if (raygunMessage == null) {
                         return -1;
@@ -123,13 +123,13 @@ public class RaygunClient {
                     responseCode = send(jsonPayload);
                 } catch (Exception e) {
                     if (onFailedSend != null) {
-                        onFailedSend.handle(jsonPayload, e);
+                        onFailedSend.onFailedSend(this, jsonPayload);
                     }
                 }
 
                 try {
                     if(onAfterSend != null) {
-                        onAfterSend.onAfterSend(raygunMessage);
+                        onAfterSend.onAfterSend(this, raygunMessage);
                     }
                 } catch (Exception e) {
                     Logger.getLogger("Raygun4Java").warning("exception processing onAfterSend: " + e.getMessage());
@@ -144,7 +144,7 @@ public class RaygunClient {
         return -1;
     }
 
-    private int send(String payload) throws IOException {
+    public int send(String payload) throws IOException {
         HttpURLConnection connection = this.raygunConnection.getConnection(apiKey);
 
         OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream(), "UTF8");
@@ -165,6 +165,10 @@ public class RaygunClient {
 
     public void setOnAfterSend(IRaygunOnAfterSend onAfterSend) {
         this.onAfterSend = onAfterSend;
+    }
+
+    public void setOnFailedSend(IRaygunOnFailedSend onFailedSend) {
+        this.onFailedSend = onFailedSend;
     }
 
     public IRaygunOnBeforeSend getOnBeforeSend() {

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClient.java
@@ -125,6 +125,7 @@ public class RaygunClient {
                     if (onFailedSend != null) {
                         onFailedSend.onFailedSend(this, jsonPayload);
                     }
+                    return responseCode;
                 }
 
                 try {

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
@@ -153,7 +153,7 @@ public class RaygunClientFactory implements IRaygunClientFactory {
     }
 
     public IRaygunClientFactory withOfflineStorage(String storageDir) {
-        RaygunOnFailedSendOfflineStorageHandler sendOfflineStorageHandler = new RaygunOnFailedSendOfflineStorageHandler(storageDir);
+        RaygunOnFailedSendOfflineStorageHandler sendOfflineStorageHandler = new RaygunOnFailedSendOfflineStorageHandler(storageDir, apiKey);
 
         onBeforeSendChainFactory.withFilterFactory(sendOfflineStorageHandler);
         onFailedSendChainFactory.withFilterFactory(sendOfflineStorageHandler);

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunClientFactory.java
@@ -1,6 +1,7 @@
 package com.mindscapehq.raygun4java.core;
 
-import com.mindscapehq.raygun4java.core.filters.RaygunDuplicateErrorFilterFactory;
+import com.mindscapehq.raygun4java.core.handlers.offlinesupport.RaygunOnFailedSendOfflineStorageHandler;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunDuplicateErrorFilterFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,7 @@ public class RaygunClientFactory implements IRaygunClientFactory {
     private String apiKey;
     private AbstractRaygunSendEventChainFactory<IRaygunOnBeforeSend> onBeforeSendChainFactory;
     private AbstractRaygunSendEventChainFactory<IRaygunOnAfterSend> onAfterSendChainFactory;
+    private AbstractRaygunSendEventChainFactory<IRaygunOnFailedSend> onFailedSendChainFactory;
     protected List<String> tags;
     protected Map data;
     private RaygunClient client;
@@ -50,8 +52,13 @@ public class RaygunClientFactory implements IRaygunClientFactory {
 
         RaygunDuplicateErrorFilterFactory duplicateErrorRecordFilterFactory = new RaygunDuplicateErrorFilterFactory();
 
-        onBeforeSendChainFactory = new RaygunOnBeforeSendChainFactory().afterAll(duplicateErrorRecordFilterFactory);
-        onAfterSendChainFactory = new RaygunOnAfterSendChainFactory().withFilterFactory(duplicateErrorRecordFilterFactory);
+        onBeforeSendChainFactory = new RaygunOnBeforeSendChainFactory()
+                .afterAll(duplicateErrorRecordFilterFactory);
+
+        onAfterSendChainFactory = new RaygunOnAfterSendChainFactory()
+                .withFilterFactory(duplicateErrorRecordFilterFactory);
+
+        onFailedSendChainFactory = new RaygunOnFailedSendChainFactory();
     }
 
     /**
@@ -81,12 +88,26 @@ public class RaygunClientFactory implements IRaygunClientFactory {
     }
 
     /**
+     * Add a RaygunOnFailedSend handler
+     *
+     * factory.withFailedSend(myRaygunOnFailedSendFactory)
+     *
+     * @param onFailedSend
+     * @return factory
+     */
+    public IRaygunClientFactory withFailedSend(IRaygunSendEventFactory<IRaygunOnFailedSend> onFailedSend) {
+        this.onFailedSendChainFactory.withFilterFactory(onFailedSend);
+        return this;
+    }
+
+    /**
      * @return a new RaygunClient configured by this factory
      */
     public RaygunClient newClient() {
         RaygunClient client = new RaygunClient(apiKey);
         client.setOnBeforeSend(onBeforeSendChainFactory.create());
         client.setOnAfterSend(onAfterSendChainFactory.create());
+        client.setOnFailedSend(onFailedSendChainFactory.create());
         client.string = version;
         client.shouldProcessBreadcrumbLocation(shouldProcessBreadcrumbLocations);
         client.setTags(new ArrayList<String>(tags));
@@ -101,6 +122,10 @@ public class RaygunClientFactory implements IRaygunClientFactory {
 
     public AbstractRaygunSendEventChainFactory getRaygunOnAfterSendChainFactory() {
         return onAfterSendChainFactory;
+    }
+
+    public AbstractRaygunSendEventChainFactory getRaygunOnFailedSendChainFactory() {
+        return onFailedSendChainFactory;
     }
 
     public IRaygunClientFactory withApiKey(String apiKey) {
@@ -120,6 +145,19 @@ public class RaygunClientFactory implements IRaygunClientFactory {
 
     public IRaygunClientFactory withMessageBuilder(IRaygunMessageBuilderFactory messageBuilderFactory) {
         this.raygunMessageBuilderFactory = messageBuilderFactory;
+        return this;
+    }
+
+    public IRaygunClientFactory withOfflineStorage() {
+        return withOfflineStorage("");
+    }
+
+    public IRaygunClientFactory withOfflineStorage(String storageDir) {
+        RaygunOnFailedSendOfflineStorageHandler sendOfflineStorageHandler = new RaygunOnFailedSendOfflineStorageHandler(storageDir);
+
+        onBeforeSendChainFactory.withFilterFactory(sendOfflineStorageHandler);
+        onFailedSendChainFactory.withFilterFactory(sendOfflineStorageHandler);
+
         return this;
     }
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunConnection.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunConnection.java
@@ -20,7 +20,7 @@ public class RaygunConnection {
         this.raygunSettings = raygunSettings;
     }
 
-    public HttpURLConnection getConnection(String apiKey) throws MalformedURLException, IOException {
+    public HttpURLConnection getConnection(String apiKey) throws IOException {
 
         HttpURLConnection connection = null;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnAfterSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnAfterSendChain.java
@@ -9,16 +9,16 @@ import java.util.List;
  *
  * Instances are not shared between RaygunClient instances
  */
-public class RaygunOnAfterSendChain extends AbstractRaygunOnSendEventChain<IRaygunOnAfterSend> implements IRaygunOnAfterSend {
+public class RaygunOnAfterSendChain extends AbstractRaygunOnSendEventChain<IRaygunOnAfterSend, RaygunMessage> implements IRaygunOnAfterSend {
     public RaygunOnAfterSendChain(List<IRaygunOnAfterSend> handlers) {
         super(handlers);
     }
 
-    public RaygunMessage handle(IRaygunOnAfterSend handler, RaygunMessage message) {
-        return handler.onAfterSend(message);
+    public RaygunMessage handle(RaygunClient client, IRaygunOnAfterSend handler, RaygunMessage message) {
+        return handler.onAfterSend(client, message);
     }
 
-    public RaygunMessage onAfterSend(RaygunMessage message) {
-        return handle(message);
+    public RaygunMessage onAfterSend(RaygunClient client, RaygunMessage message) {
+        return handle(client, message);
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChain.java
@@ -9,16 +9,16 @@ import java.util.List;
  *
  * Instances are not shared between RaygunClient instances
  */
-public class RaygunOnBeforeSendChain extends AbstractRaygunOnSendEventChain<IRaygunOnBeforeSend> implements IRaygunOnBeforeSend {
+public class RaygunOnBeforeSendChain extends AbstractRaygunOnSendEventChain<IRaygunOnBeforeSend, RaygunMessage> implements IRaygunOnBeforeSend {
     public RaygunOnBeforeSendChain(List<IRaygunOnBeforeSend> handlers) {
         super(handlers);
     }
 
-    public RaygunMessage handle(IRaygunOnBeforeSend handler, RaygunMessage message) {
-        return handler.onBeforeSend(message);
+    public RaygunMessage handle(RaygunClient client, IRaygunOnBeforeSend handler, RaygunMessage message) {
+        return handler.onBeforeSend(client, message);
     }
 
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
-        return handle(message);
+    public RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message) {
+        return handle(client, message);
     }
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendChain.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendChain.java
@@ -1,0 +1,24 @@
+package com.mindscapehq.raygun4java.core;
+
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
+
+import java.util.List;
+
+/**
+ * This is a OnFailedSend chain handler.
+ *
+ * Instances are not shared between RaygunClient instances
+ */
+public class RaygunOnFailedSendChain extends AbstractRaygunOnSendEventChain<IRaygunOnFailedSend, String> implements IRaygunOnFailedSend {
+    public RaygunOnFailedSendChain(List<IRaygunOnFailedSend> handlers) {
+        super(handlers);
+    }
+
+    public String handle(RaygunClient client, IRaygunOnFailedSend handler, String message) {
+        return handler.onFailedSend(client, message);
+    }
+
+    public String onFailedSend(RaygunClient client, String message) {
+        return handle(client, message);
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendChainFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendChainFactory.java
@@ -1,0 +1,23 @@
+package com.mindscapehq.raygun4java.core;
+
+import java.util.List;
+
+/**
+ * A factory used to create RaygunOnFailedSendChain for a new RaygunClient
+ *
+ * usage:
+ * raygunClient.setOnFailedSend(
+ *      new RaygunOnFailedSendChainFactory()
+ *          .beforeAll(executeFirstFactory)
+ *          .withFilterFactory(aFilterFactory),
+ *          .withFilterFactory(anotherFilterFactory)
+ *          .afterAll(executeAfterFactory)
+ *      )
+ *      .create()
+ * );
+ */
+public class RaygunOnFailedSendChainFactory extends AbstractRaygunSendEventChainFactory<IRaygunOnFailedSend> {
+    protected RaygunOnFailedSendChain create(List<IRaygunOnFailedSend> handlers) {
+        return new RaygunOnFailedSendChain(handlers);
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendOfflineStorageHandler.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendOfflineStorageHandler.java
@@ -1,0 +1,99 @@
+package com.mindscapehq.raygun4java.core;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Random;
+import java.util.logging.Logger;
+
+public class RaygunOnFailedSendOfflineStorageHandler implements IRaygunOnFailedSend {
+
+    private Random random = new Random();
+    private String storageDir;
+    private File storage;
+    boolean enabled = true;
+    private boolean exceptionLogged = false;
+
+    public RaygunOnFailedSendOfflineStorageHandler(String storageDir) {
+        this.storageDir = storageDir;
+    }
+
+    public void handle(String jsonPayload, Exception e) {
+        if (!enabled) {
+            return;
+        }
+        OutputStream fileOutputStream = null;
+        try {
+            File file = createFile();
+
+            if (file == null) {
+                return;
+            }
+
+            fileOutputStream = getOutputStream(file);
+            fileOutputStream.write(jsonPayload.getBytes());
+
+            exceptionLogged = false;
+        } catch (Exception e1) {
+            if(!exceptionLogged) {
+                Logger.getLogger("Raygun4Java").warning("exception adding to offline storage: " + e1.getMessage());
+                exceptionLogged = true;
+            }
+        } finally {
+            if (fileOutputStream != null) {
+                try {
+                    fileOutputStream.close();
+                } catch (IOException e1) {
+                    Logger.getLogger("Raygun4Java").warning("exception closing file stream: " + e1.getMessage());
+                }
+            }
+
+        }
+    }
+    File createFile() {
+        try {
+            if (storage == null) {
+                synchronized (this) {
+                    if (storage == null) {
+                        storage = createStorage(storageDir);
+
+                        if (!storage.exists()) {
+                            if(!storage.mkdirs()) {
+                                return disable();
+                            }
+                        }
+                    }
+                }
+            }
+
+            File file = createFile(storageDir, random.nextInt()+".json");
+
+            if (!file.createNewFile()) {
+                return disable();
+            }
+
+            return file;
+        } catch (Exception e) {
+            return disable();
+        }
+    }
+
+    OutputStream getOutputStream(File file) throws FileNotFoundException {
+        return new FileOutputStream(file);
+    }
+
+    File createStorage(String storageDir) {
+        return new File(storageDir);
+    }
+
+    File createFile(String storageDir, String name) {
+        return new File(storageDir, name);
+    }
+
+    private File disable() {
+        enabled = false;
+        return null;
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunSettings.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/RaygunSettings.java
@@ -56,7 +56,11 @@ public class RaygunSettings {
      * @param port The TCP port
      */
     public void setHttpProxy(String host, int port) {
-        this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port));
+        if (host == null) {
+            this.proxy = null;
+        } else {
+            this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port));
+        }
     }
 
 }

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunOnFailedSendOfflineStorageHandler.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunOnFailedSendOfflineStorageHandler.java
@@ -113,7 +113,7 @@ public class RaygunOnFailedSendOfflineStorageHandler implements IRaygunOnFailedS
                 }
             }
 
-            File file = createFile(storageDir, random.nextInt()+ fileExtension);
+            File file = createFile(storage, random.nextInt()+ fileExtension);
 
             if (!file.createNewFile()) {
                 return disable();
@@ -130,11 +130,11 @@ public class RaygunOnFailedSendOfflineStorageHandler implements IRaygunOnFailedS
     }
 
     File createStorage(String storageDir) {
-        return new File(storageDir);
+        return new File(new File(storageDir).getAbsolutePath(), ".raygun_offline_storage").getAbsoluteFile();
     }
 
-    File createFile(String storageDir, String name) {
-        return new File(storageDir, name);
+    File createFile(File storage, String name) {
+        return new File(storage, name);
     }
 
     private File disable() {

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptions.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptions.java
@@ -1,0 +1,83 @@
+package com.mindscapehq.raygun4java.core.handlers.offlinesupport;
+
+import com.mindscapehq.raygun4java.core.RaygunClient;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Logger;
+
+public class RaygunSendStoredExceptions implements Runnable {
+    private final RaygunClient client;
+    private final File storage;
+
+    public RaygunSendStoredExceptions(RaygunClient client, File storage) {
+        this.client = client;
+        this.storage = storage;
+    }
+
+    public void run() {
+        processFiles();
+
+        // one final time just in case some more have arrived since then
+        processFiles();
+    }
+
+    void processFiles() {
+
+        File[] files = storage.listFiles(new FilenameFilter() {
+            public boolean accept(File dir, String name) {
+                return name.endsWith(RaygunOnFailedSendOfflineStorageHandler.fileExtension);
+            }
+        });
+
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            InputStream inputStream = null;
+            ByteArrayOutputStream outputStream = null;
+            try {
+                inputStream = getInputStream(file);
+                outputStream = new ByteArrayOutputStream();
+                byte[] buffer = new byte[(int) file.length()];
+                int length;
+                while ((length = inputStream.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, length);
+                }
+
+                int reponseCode = client.send(outputStream.toString("UTF-8"));
+                if (reponseCode == 202 || reponseCode == 429 /* rate limited */) {
+                    file.delete();
+                }
+            } catch (IOException e) {
+                Logger.getLogger("Raygun4Java").warning("exception processing offline payload: " + e.getMessage());
+                return;
+            } finally {
+                if (outputStream != null) {
+                    try {
+                        outputStream.close();
+                    } catch (IOException e) {
+                        Logger.getLogger("Raygun4Java").warning("exception closing outputStream: " + e.getMessage());
+                    }
+                }
+                if (inputStream != null) {
+                    try {
+                        inputStream.close();
+                    } catch (IOException e) {
+                        Logger.getLogger("Raygun4Java").warning("exception closing inputStream: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    InputStream getInputStream(File file) throws FileNotFoundException {
+        return new FileInputStream(file);
+    }
+}

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptions.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptions.java
@@ -50,6 +50,7 @@ public class RaygunSendStoredExceptions implements Runnable {
                 while ((length = inputStream.read(buffer)) != -1) {
                     outputStream.write(buffer, 0, length);
                 }
+                inputStream.close();
 
                 int reponseCode = client.send(outputStream.toString("UTF-8"));
                 if (reponseCode == 202 || reponseCode == 429 /* rate limited */) {

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/AbstractRaygunRequestMapFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/AbstractRaygunRequestMapFilter.java
@@ -1,7 +1,8 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.IRaygunSendEventFactory;
+import com.mindscapehq.raygun4java.core.RaygunClient;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
@@ -25,7 +26,7 @@ public abstract class AbstractRaygunRequestMapFilter<T> implements IRaygunOnBefo
         this.replacement = replacement;
     }
 
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
+    public RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message) {
 
         if (message.getDetails() != null && message.getDetails() instanceof RaygunRequestMessageDetails) {
             RaygunRequestMessageDetails requestMessageDetails = (RaygunRequestMessageDetails) message.getDetails();

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunDuplicateErrorFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunDuplicateErrorFilter.java
@@ -1,7 +1,8 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.IRaygunOnAfterSend;
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.RaygunClient;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
 import java.util.Map;
@@ -20,7 +21,7 @@ public class RaygunDuplicateErrorFilter implements IRaygunOnBeforeSend, IRaygunO
      * @param message to check if the error has already been sent
      * @return message
      */
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
+    public RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message) {
         if (message.getDetails() != null
                 && message.getDetails().getError() != null
                 && message.getDetails().getError().getThrowable() != null) {
@@ -35,7 +36,7 @@ public class RaygunDuplicateErrorFilter implements IRaygunOnBeforeSend, IRaygunO
      * @param message to mark as sent
      * @return
      */
-    public RaygunMessage onAfterSend(RaygunMessage message) {
+    public RaygunMessage onAfterSend(RaygunClient client, RaygunMessage message) {
         if (message.getDetails() != null
                 && message.getDetails().getError() != null
                 && message.getDetails().getError().getThrowable() != null) {

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunDuplicateErrorFilterFactory.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunDuplicateErrorFilterFactory.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.IRaygunSendEventFactory;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunExcludeLocalRequestFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunExcludeLocalRequestFilter.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunExcludeRequestFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunExcludeRequestFilter.java
@@ -1,7 +1,8 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.IRaygunSendEventFactory;
+import com.mindscapehq.raygun4java.core.RaygunClient;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 
@@ -16,7 +17,7 @@ public class RaygunExcludeRequestFilter implements IRaygunOnBeforeSend, IRaygunS
         this.filter = filter;
     }
 
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
+    public RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message) {
 
         if (message.getDetails() != null && message.getDetails() instanceof RaygunRequestMessageDetails) {
             RaygunRequestMessageDetails requestMessageDetails = (RaygunRequestMessageDetails) message.getDetails();

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestCookieFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestCookieFilter.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestFormFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestFormFilter.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestHeaderFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestHeaderFilter.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestHttpStatusFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestHttpStatusFilter.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestQueryStringFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestQueryStringFilter.java
@@ -1,4 +1,4 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 

--- a/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunStripWrappedExceptionFilter.java
+++ b/core/src/main/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunStripWrappedExceptionFilter.java
@@ -1,7 +1,8 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.IRaygunSendEventFactory;
+import com.mindscapehq.raygun4java.core.RaygunClient;
 import com.mindscapehq.raygun4java.core.messages.RaygunErrorMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 
@@ -17,7 +18,7 @@ public class RaygunStripWrappedExceptionFilter implements IRaygunOnBeforeSend, I
         this.stripClasses = stripClasses;
     }
 
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
+    public RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message) {
 
         if(message.getDetails() != null
                 && message.getDetails().getError() != null
@@ -30,7 +31,7 @@ public class RaygunStripWrappedExceptionFilter implements IRaygunOnBeforeSend, I
                     message.getDetails().setError(innerError);
 
                     // rerun check on the reassigned error
-                    onBeforeSend(message);
+                    onBeforeSend(client, message);
                 }
             }
         }

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -218,10 +218,11 @@ public class RaygunClientTest {
         when(raygunConnectionMock.getConnection(anyString())).thenThrow(new IOException());
         raygunClient.onFailedSend = mock(IRaygunOnFailedSend.class);
         raygunClient.onAfterSend = mock(IRaygunOnAfterSend.class);
-        raygunClient.send(new RaygunMessage());
+
+        assertThat(raygunClient.send(new RaygunMessage()), is(-1));
 
         verify(raygunClient.onFailedSend, times(1)).onFailedSend(eq(raygunClient), anyString());
-        verify(raygunClient.onAfterSend, times(1)).onAfterSend(eq(raygunClient), (RaygunMessage) anyObject());
+        verify(raygunClient.onAfterSend, times(0)).onAfterSend(eq(raygunClient), (RaygunMessage) anyObject());
     }
 
     private RaygunMessage fromJson() {

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -158,12 +158,12 @@ public class RaygunClientTest {
     public void post_SendWithOnBeforeSend_Returns202() throws IOException {
         IRaygunOnBeforeSend handler = mock(IRaygunOnBeforeSend.class);
         RaygunMessage message = new RaygunMessage();
-        when(handler.onBeforeSend((RaygunMessage) anyObject())).thenReturn(message);
+        when(handler.onBeforeSend((RaygunClient) anyObject(), (RaygunMessage) anyObject())).thenReturn(message);
         raygunClient.setOnBeforeSend(handler);
 
         assertEquals(202, raygunClient.send(new Exception()));
 
-        verify(handler).onBeforeSend((RaygunMessage) anyObject());
+        verify(handler).onBeforeSend(eq(raygunClient), (RaygunMessage) anyObject());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class RaygunClientTest {
 
         assertEquals(202, this.raygunClient.send(new Exception()));
 
-        verify(handler).onAfterSend((RaygunMessage) anyObject());
+        verify(handler).onAfterSend(eq(raygunClient), (RaygunMessage) anyObject());
     }
 
     @Test
@@ -220,8 +220,8 @@ public class RaygunClientTest {
         raygunClient.onAfterSend = mock(IRaygunOnAfterSend.class);
         raygunClient.send(new RaygunMessage());
 
-        verify(raygunClient.onFailedSend, times(1)).handle(anyString(), (Exception) anyObject());
-        verify(raygunClient.onAfterSend, times(1)).onAfterSend((RaygunMessage) anyObject());
+        verify(raygunClient.onFailedSend, times(1)).onFailedSend(eq(raygunClient), anyString());
+        verify(raygunClient.onAfterSend, times(1)).onAfterSend(eq(raygunClient), (RaygunMessage) anyObject());
     }
 
     private RaygunMessage fromJson() {

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunClientTest.java
@@ -25,7 +25,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,7 +52,7 @@ public class RaygunClientTest {
         assertThat(assertBreadcrumb.getLevel(), is(RaygunBreadcrumbLevel.INFO));
         assertThat(assertBreadcrumb.getClassName(), is("com.mindscapehq.raygun4java.core.RaygunClientTest"));
         assertThat(assertBreadcrumb.getMethodName(), is("shouldAddBreadCrumbFromMessageWithLocation"));
-        assertThat(assertBreadcrumb.getLineNumber(), is(44));
+        assertThat(assertBreadcrumb.getLineNumber(), is(47));
     }
 
     @Test
@@ -63,7 +66,7 @@ public class RaygunClientTest {
         assertThat(assertBreadcrumb.getLevel(), is(RaygunBreadcrumbLevel.INFO));
         assertThat(assertBreadcrumb.getClassName(), is("com.mindscapehq.raygun4java.core.RaygunClientTest"));
         assertThat(assertBreadcrumb.getMethodName(), is("shouldAddBreadCrumbMessageWithLocation"));
-        assertThat(assertBreadcrumb.getLineNumber(), is(58));
+        assertThat(assertBreadcrumb.getLineNumber(), is(61));
     }
 
     //////////////////////////////
@@ -208,6 +211,17 @@ public class RaygunClientTest {
         assertThat(breadcrumb.getMessage(), is("hello there"));
         assertThat(breadcrumb.getCategory(), is("greetings"));
         assertNotNull(breadcrumb.getTimestamp());
+    }
+
+    @Test
+    public void shouldUseOnFailHandler() throws IOException {
+        when(raygunConnectionMock.getConnection(anyString())).thenThrow(new IOException());
+        raygunClient.onFailedSend = mock(IRaygunOnFailedSend.class);
+        raygunClient.onAfterSend = mock(IRaygunOnAfterSend.class);
+        raygunClient.send(new RaygunMessage());
+
+        verify(raygunClient.onFailedSend, times(1)).handle(anyString(), (Exception) anyObject());
+        verify(raygunClient.onAfterSend, times(1)).onAfterSend((RaygunMessage) anyObject());
     }
 
     private RaygunMessage fromJson() {

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChainTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunOnBeforeSendChainTest.java
@@ -38,7 +38,7 @@ public class RaygunOnBeforeSendChainTest {
 
     @Test
     public void shouldExecuteAllOnHappyPath() {
-        assertThat(chain.handle(message), is(message));
+        assertThat(chain.onFailedSend(message), is(message));
 
         verify(first).onBeforeSend(message);
         verify(main).onBeforeSend(message);
@@ -49,7 +49,7 @@ public class RaygunOnBeforeSendChainTest {
     public void shouldFilterOnFirstFilter() {
         when(first.onBeforeSend(message)).thenReturn(null);
 
-        assertNull(chain.handle(message));
+        assertNull(chain.onFailedSend(message));
 
         verify(first).onBeforeSend(message);
         verify(main, never()).onBeforeSend(message);
@@ -60,7 +60,7 @@ public class RaygunOnBeforeSendChainTest {
     public void shouldFilterOnMainFilter() {
         when(main.onBeforeSend(message)).thenReturn(null);
 
-        assertNull(chain.handle(message));
+        assertNull(chain.onFailedSend(message));
 
         verify(first).onBeforeSend(message);
         verify(main).onBeforeSend(message);
@@ -71,7 +71,7 @@ public class RaygunOnBeforeSendChainTest {
     public void shouldFilterOnLastFilter() {
         when(last.onBeforeSend(message)).thenReturn(null);
 
-        assertNull(chain.handle(message));
+        assertNull(chain.onFailedSend(message));
 
         verify(first).onBeforeSend(message);
         verify(main).onBeforeSend(message);
@@ -79,7 +79,7 @@ public class RaygunOnBeforeSendChainTest {
     }
 
     private interface ForTest extends IRaygunSendEventFactory, IRaygunOnBeforeSend, IRaygunOnAfterSend {
-        RaygunMessage handle(RaygunMessage message);
+        RaygunMessage onFailedSend(RaygunMessage message);
         RaygunMessage onBeforeSend(RaygunMessage message);
         ForTest create();
     }*/

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendOfflineStorageHandlerTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/RaygunOnFailedSendOfflineStorageHandlerTest.java
@@ -1,0 +1,135 @@
+package com.mindscapehq.raygun4java.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RaygunOnFailedSendOfflineStorageHandlerTest {
+
+    private RaygunOnFailedSendOfflineStorageHandler handler;
+    private final String storageDir = "storage";
+
+    @Mock
+    private File storage, file;
+    @Mock
+    private OutputStream outputStream;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        handler = new RaygunOnFailedSendOfflineStorageHandler(storageDir) {
+            @Override
+            File createStorage(String storageDir) {
+                return storage;
+            }
+
+            @Override
+            File createFile(String storageDir, String name) {
+                return file;
+            }
+
+            @Override
+            OutputStream getOutputStream(File file) throws FileNotFoundException {
+                return outputStream;
+            }
+        };
+
+        when(storage.exists()).thenReturn(true);
+        when(file.createNewFile()).thenReturn(true);
+    }
+
+    @Test
+    public void shouldWritePayloadToFile() throws IOException {
+        handler.handle("payload", null);
+
+        verify(outputStream).write("payload".getBytes());
+        verify(outputStream).close();
+    }
+
+    @Test
+    public void shouldNotWritePayloadToFileIfDisabled() throws IOException {
+        handler.enabled = false;
+        handler.handle("payload", null);
+
+        verify(outputStream, never()).write((byte[]) anyObject());
+    }
+
+    @Test
+    public void shouldDisableIfCanMakeStorageDirs() throws IOException {
+        handler = new RaygunOnFailedSendOfflineStorageHandler(storageDir) {
+            @Override
+            File createStorage(String storageDir) {
+                return storage;
+            }
+
+            @Override
+            OutputStream getOutputStream(File file) throws FileNotFoundException {
+                return outputStream;
+            }
+        };
+
+        when(storage.exists()).thenReturn(false);
+        when(storage.mkdirs()).thenReturn(false);
+
+        handler.handle("payload", null);
+
+        verify(outputStream, never()).write((byte[]) anyObject());
+        assertFalse(handler.enabled);
+    }
+
+    @Test
+    public void shouldDisableIfCanMakeFile() throws IOException {
+        handler = new RaygunOnFailedSendOfflineStorageHandler(storageDir) {
+            @Override
+            File createStorage(String storageDir) {
+                return storage;
+            }
+
+            @Override
+            OutputStream getOutputStream(File file) throws FileNotFoundException {
+                return outputStream;
+            }
+
+            @Override
+            File createFile(String storageDir, String name) {
+                return file;
+            }
+        };
+
+        when(file.createNewFile()).thenReturn(false);
+
+        handler.handle("payload", null);
+
+        verify(outputStream, never()).write((byte[]) anyObject());
+        assertFalse(handler.enabled);
+    }
+
+    @Test
+    public void shouldDisableOnFileCreateException() throws IOException {
+        handler = new RaygunOnFailedSendOfflineStorageHandler(storageDir) {
+            @Override
+            File createStorage(String storageDir) {
+                throw new RuntimeException();
+            }
+        };
+
+        when(file.createNewFile()).thenThrow(new RuntimeException());
+
+        handler.handle("payload", null);
+
+        verify(outputStream, never()).write((byte[]) anyObject());
+        assertFalse(handler.enabled);
+    }
+}

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunOnFailedSendOfflineStorageHandlerTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunOnFailedSendOfflineStorageHandlerTest.java
@@ -1,5 +1,7 @@
-package com.mindscapehq.raygun4java.core;
+package com.mindscapehq.raygun4java.core.handlers.offlinesupport;
 
+import com.mindscapehq.raygun4java.core.RaygunClient;
+import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -7,12 +9,18 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,14 +33,17 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
     private File storage, file;
     @Mock
     private OutputStream outputStream;
+    @Mock
+    private RaygunClient client;
 
     @Before
     public void setup() throws IOException {
         MockitoAnnotations.initMocks(this);
+        final File storageMock = storage;
         handler = new RaygunOnFailedSendOfflineStorageHandler(storageDir) {
             @Override
             File createStorage(String storageDir) {
-                return storage;
+                return storageMock;
             }
 
             @Override
@@ -52,16 +63,18 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
 
     @Test
     public void shouldWritePayloadToFile() throws IOException {
-        handler.handle("payload", null);
+        handler.onFailedSend(null, "payload");
 
         verify(outputStream).write("payload".getBytes());
         verify(outputStream).close();
+
+        assertTrue(handler.hasStoredExceptions);
     }
 
     @Test
     public void shouldNotWritePayloadToFileIfDisabled() throws IOException {
         handler.enabled = false;
-        handler.handle("payload", null);
+        handler.onFailedSend(null, "payload");
 
         verify(outputStream, never()).write((byte[]) anyObject());
     }
@@ -83,7 +96,7 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
         when(storage.exists()).thenReturn(false);
         when(storage.mkdirs()).thenReturn(false);
 
-        handler.handle("payload", null);
+        handler.onFailedSend(null, "payload");
 
         verify(outputStream, never()).write((byte[]) anyObject());
         assertFalse(handler.enabled);
@@ -110,7 +123,7 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
 
         when(file.createNewFile()).thenReturn(false);
 
-        handler.handle("payload", null);
+        handler.onFailedSend(null, "payload");
 
         verify(outputStream, never()).write((byte[]) anyObject());
         assertFalse(handler.enabled);
@@ -127,9 +140,28 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
 
         when(file.createNewFile()).thenThrow(new RuntimeException());
 
-        handler.handle("payload", null);
+        handler.onFailedSend(null, "payload");
 
         verify(outputStream, never()).write((byte[]) anyObject());
         assertFalse(handler.enabled);
+        assertFalse(handler.hasStoredExceptions);
+    }
+
+    @Test
+    public void shouldSendStoredExceptionsOnce() throws InterruptedException {
+        handler.enabled = true;
+        handler.hasStoredExceptions = true;
+        RaygunMessage message = mock(RaygunMessage.class);
+        when(storage.listFiles((FilenameFilter) anyObject())).thenReturn(new File[0]);
+        handler.storage = storage;
+
+        assertThat(handler.onBeforeSend(client, message), is(message));
+
+        Thread.sleep(200);
+        verify(storage, times(2)).listFiles((FilenameFilter) anyObject());
+
+        assertThat(handler.onBeforeSend(client, message), is(message));
+        Thread.sleep(200);
+        verify(storage, times(2)).listFiles((FilenameFilter) anyObject());
     }
 }

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunOnFailedSendOfflineStorageHandlerTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunOnFailedSendOfflineStorageHandlerTest.java
@@ -47,7 +47,7 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
             }
 
             @Override
-            File createFile(String storageDir, String name) {
+            File createFile(File storage, String name) {
                 return file;
             }
 
@@ -116,7 +116,7 @@ public class RaygunOnFailedSendOfflineStorageHandlerTest {
             }
 
             @Override
-            File createFile(String storageDir, String name) {
+            File createFile(File storage, String name) {
                 return file;
             }
         };

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptionsTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptionsTest.java
@@ -1,0 +1,56 @@
+package com.mindscapehq.raygun4java.core.handlers.offlinesupport;
+
+import com.mindscapehq.raygun4java.core.RaygunClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class RaygunSendStoredExceptionsTest {
+
+    @Mock
+    RaygunClient client;
+    @Mock
+    File storage, file;
+
+    InputStream inputStream;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+
+        File[] files = { file };
+        when(file.length()).thenReturn((long) "hello world".length());
+        when(storage.listFiles((FilenameFilter) anyObject())).thenReturn(files);
+        when(client.send(anyString())).thenReturn(202);
+
+        inputStream = new ByteArrayInputStream("hello world".getBytes());
+    }
+
+    @Test
+    public void processFilesShouldProcessRaygunFilesOnly() throws IOException {
+        RaygunSendStoredExceptions sendStoredExceptions = new RaygunSendStoredExceptions(client, storage) {
+            @Override
+            InputStream getInputStream(File file) {
+                return inputStream;
+            }
+        };
+
+        sendStoredExceptions.processFiles();
+
+        Mockito.verify(client).send("hello world");
+
+    }
+
+}

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptionsTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptionsTest.java
@@ -42,6 +42,11 @@ public class RaygunSendStoredExceptionsTest {
     }
 
     @Test
+    public void shouldNotSendWhenStorageNotInitialized() {
+        new RaygunSendStoredExceptions(client, null).run();
+    }
+
+    @Test
     public void processFilesShouldProcessRaygunFilesOnly() throws IOException {
         RaygunSendStoredExceptions sendStoredExceptions = new RaygunSendStoredExceptions(client, storage) {
             @Override

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptionsTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/offlinesupport/RaygunSendStoredExceptionsTest.java
@@ -15,6 +15,9 @@ import java.io.InputStream;
 
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RaygunSendStoredExceptionsTest {
@@ -35,7 +38,7 @@ public class RaygunSendStoredExceptionsTest {
         when(storage.listFiles((FilenameFilter) anyObject())).thenReturn(files);
         when(client.send(anyString())).thenReturn(202);
 
-        inputStream = new ByteArrayInputStream("hello world".getBytes());
+        inputStream = spy(new ByteArrayInputStream("hello world".getBytes()));
     }
 
     @Test
@@ -49,8 +52,8 @@ public class RaygunSendStoredExceptionsTest {
 
         sendStoredExceptions.processFiles();
 
-        Mockito.verify(client).send("hello world");
-
+        verify(client).send("hello world");
+        verify(inputStream, times(2)).close();
     }
 
 }

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunDuplicateErrorFilterTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunDuplicateErrorFilterTest.java
@@ -1,5 +1,7 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunDuplicateErrorFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunDuplicateErrorFilterFactory;
 import com.mindscapehq.raygun4java.core.messages.RaygunErrorMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessageDetails;
@@ -22,8 +24,8 @@ public class RaygunDuplicateErrorFilterTest {
         details.setError(error);
         message.setDetails(details);
 
-        assertEquals(message, filter.onBeforeSend(message)); // not filtered first time
-        filter.onAfterSend(message);
+        assertEquals(message, filter.onBeforeSend(null, message)); // not filtered first time
+        filter.onAfterSend(null, message);
 
         message = new RaygunMessage();
         details = new RaygunMessageDetails();
@@ -31,14 +33,14 @@ public class RaygunDuplicateErrorFilterTest {
         details.setError(error);
         message.setDetails(details);
 
-        assertNull(filter.onBeforeSend(message)); // filtered second time
+        assertNull(filter.onBeforeSend(null, message)); // filtered second time
 
         message = new RaygunMessage();
         details = new RaygunMessageDetails();
         error = new RaygunErrorMessage(new Exception()); // different exception
         details.setError(error);
         message.setDetails(details);
-        assertEquals(message, filter.onBeforeSend(message)); // not filtered
+        assertEquals(message, filter.onBeforeSend(null, message)); // not filtered
     }
 
     @Test

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunExcludeLocalRequestFilterTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunExcludeLocalRequestFilterTest.java
@@ -1,5 +1,6 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunExcludeLocalRequestFilter;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
@@ -29,7 +30,7 @@ public class RaygunExcludeLocalRequestFilterTest {
         details.setRequest(request);
         localMessage.setDetails(details);
 
-        assertNull(new RaygunExcludeLocalRequestFilter().onBeforeSend(localMessage));
+        assertNull(new RaygunExcludeLocalRequestFilter().onBeforeSend(null, localMessage));
     }
 
     @Test
@@ -39,7 +40,7 @@ public class RaygunExcludeLocalRequestFilterTest {
         details.setRequest(request);
         localMessage.setDetails(details);
 
-        assertNotNull(new RaygunExcludeLocalRequestFilter().onBeforeSend(localMessage));
+        assertNotNull(new RaygunExcludeLocalRequestFilter().onBeforeSend(null, localMessage));
     }
 
     @Test

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestHttpStatusFilterTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunRequestHttpStatusFilterTest.java
@@ -1,6 +1,7 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunRequestHttpStatusFilter;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunRequestMessageDetails;
@@ -22,7 +23,7 @@ public class RaygunRequestHttpStatusFilterTest {
         requestDetails.setRequest(new RaygunRequestMessage());
         requestDetails.setResponse(response);
         message.setDetails(requestDetails);
-        assertNull(filter.onBeforeSend(message));
+        assertNull(filter.onBeforeSend(null, message));
     }
 
     @Test

--- a/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunStripWrappedExceptionFilterTest.java
+++ b/core/src/test/java/com/mindscapehq/raygun4java/core/handlers/requestfilters/RaygunStripWrappedExceptionFilterTest.java
@@ -1,9 +1,7 @@
-package com.mindscapehq.raygun4java.core.filters;
+package com.mindscapehq.raygun4java.core.handlers.requestfilters;
 
 import com.mindscapehq.raygun4java.core.messages.RaygunErrorMessage;
 import com.mindscapehq.raygun4java.core.messages.RaygunMessage;
-import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -17,7 +15,7 @@ public class RaygunStripWrappedExceptionFilterTest {
 
         RaygunMessage message = new RaygunMessage();
         message.getDetails().setError(new RaygunErrorMessage(new ClassNotFoundException("wrapper", new Exception("keep me!"))));
-        f.onBeforeSend(message);
+        f.onBeforeSend(null, message);
 
         assertThat(message.getDetails().getError().getMessage(), is("Exception: keep me!"));
     }
@@ -28,7 +26,7 @@ public class RaygunStripWrappedExceptionFilterTest {
 
         RaygunMessage message = new RaygunMessage();
         message.getDetails().setError(new RaygunErrorMessage(new ClassNotFoundException("wrapper", new Exception("keep me!"))));
-        f.onBeforeSend(message);
+        f.onBeforeSend(null, message);
 
         assertThat(message.getDetails().getError().getMessage(), is("ClassNotFoundException: wrapper"));
     }
@@ -39,7 +37,7 @@ public class RaygunStripWrappedExceptionFilterTest {
 
         RaygunMessage message = new RaygunMessage();
         message.getDetails().setError(new RaygunErrorMessage(new Exception("keep me!", new ClassNotFoundException("keep me too!"))));
-        f.onBeforeSend(message);
+        f.onBeforeSend(null, message);
 
         assertThat(message.getDetails().getError().getMessage(), is("Exception: keep me!"));
     }
@@ -50,7 +48,7 @@ public class RaygunStripWrappedExceptionFilterTest {
 
         RaygunMessage message = new RaygunMessage();
         message.getDetails().setError(new RaygunErrorMessage(new ClassNotFoundException("wrapper1", new ClassNotFoundException("wrapper2", new Exception("keep me!")))));
-        f.onBeforeSend(message);
+        f.onBeforeSend(null, message);
 
         assertThat(message.getDetails().getError().getMessage(), is("Exception: keep me!"));
     }
@@ -61,7 +59,7 @@ public class RaygunStripWrappedExceptionFilterTest {
 
         RaygunMessage message = new RaygunMessage();
         message.getDetails().setError(new RaygunErrorMessage(new ClassNotFoundException("wrapper1", new ClassNotFoundException("wrapper2", new ClassNotFoundException("wrapper3")))));
-        f.onBeforeSend(message);
+        f.onBeforeSend(null, message);
 
         assertThat(message.getDetails().getError().getMessage(), is("ClassNotFoundException: wrapper3"));
     }
@@ -72,7 +70,7 @@ public class RaygunStripWrappedExceptionFilterTest {
 
         RaygunMessage message = new RaygunMessage();
         message.getDetails().setError(new RaygunErrorMessage(new ClassNotFoundException("wrapper1", new IllegalStateException("wrapper2", new Exception("keep me!")))));
-        f.onBeforeSend(message);
+        f.onBeforeSend(null, message);
 
         assertThat(message.getDetails().getError().getMessage(), is("Exception: keep me!"));
     }

--- a/sampleapp/src/main/java/com/mindscapehq/raygun4java/sampleapp/SampleApp.java
+++ b/sampleapp/src/main/java/com/mindscapehq/raygun4java/sampleapp/SampleApp.java
@@ -51,7 +51,7 @@ public class SampleApp {
                 } catch (Exception e) {
                     MyExceptionHandler.getClient().recordBreadcrumb("handling exception");
 
-                    // lets handle this exception - this should appear in the raygun console
+                    // lets onFailedSend this exception - this should appear in the raygun console
                     Map<String, String> customData = new HashMap<String, String>();
                     customData.put("thread id", "" + Thread.currentThread().getId());
                     MyExceptionHandler.getClient().withTag("thrown from thread").withTag("no user withData").withData("thread id", "" + Thread.currentThread().getId()).send(exceptionToThrowLater);
@@ -69,7 +69,7 @@ public class SampleApp {
 
 class BeforeSendImplementation implements IRaygunOnBeforeSend, IRaygunSendEventFactory<IRaygunOnBeforeSend> {
     @Override
-    public RaygunMessage onBeforeSend(RaygunMessage message) {
+    public RaygunMessage onBeforeSend(RaygunClient client, RaygunMessage message) {
         String errorMessage = message.getDetails().getError().getMessage();
         message.getDetails().getError().setMessage(errorMessage + " - I have been mutated by onBeforeSend");
 
@@ -126,7 +126,7 @@ class MyExceptionHandler implements Thread.UncaughtExceptionHandler {
 class MyOnAfterHandler implements IRaygunOnAfterSend, IRaygunSendEventFactory<IRaygunOnAfterSend> {
 
     @Override
-    public RaygunMessage onAfterSend(RaygunMessage message) {
+    public RaygunMessage onAfterSend(RaygunClient client, RaygunMessage message) {
         System.out.println("We sent a error to ragun!");
         return message;
     }

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/DefaultRaygunServletClientFactory.java
@@ -2,13 +2,13 @@ package com.mindscapehq.raygun4java.webprovider;
 
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.IRaygunSendEventFactory;
-import com.mindscapehq.raygun4java.core.filters.RaygunExcludeLocalRequestFilter;
-import com.mindscapehq.raygun4java.core.filters.RaygunRequestCookieFilter;
-import com.mindscapehq.raygun4java.core.filters.RaygunRequestFormFilter;
-import com.mindscapehq.raygun4java.core.filters.RaygunRequestHeaderFilter;
-import com.mindscapehq.raygun4java.core.filters.RaygunRequestHttpStatusFilter;
-import com.mindscapehq.raygun4java.core.filters.RaygunRequestQueryStringFilter;
-import com.mindscapehq.raygun4java.core.filters.RaygunStripWrappedExceptionFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunExcludeLocalRequestFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunRequestCookieFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunRequestFormFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunRequestHeaderFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunRequestHttpStatusFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunRequestQueryStringFilter;
+import com.mindscapehq.raygun4java.core.handlers.requestfilters.RaygunStripWrappedExceptionFilter;
 
 import javax.servlet.ServletContext;
 

--- a/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
+++ b/webprovider/src/main/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactory.java
@@ -51,17 +51,14 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
         data = new WeakHashMap();
 
         RaygunDuplicateErrorFilterFactory duplicateErrorRecordFilterFactory = new RaygunDuplicateErrorFilterFactory();
-        RaygunOnFailedSendOfflineStorageHandler sendOfflineStorageHandler = new RaygunOnFailedSendOfflineStorageHandler("");
 
         onBeforeSendChainFactory = new RaygunOnBeforeSendChainFactory()
-                .withFilterFactory(sendOfflineStorageHandler)
                 .afterAll(duplicateErrorRecordFilterFactory);
 
         onAfterSendChainFactory = new RaygunOnAfterSendChainFactory()
                 .withFilterFactory(duplicateErrorRecordFilterFactory);
 
-        onFailedSendChainFactory = new RaygunOnFailedSendChainFactory()
-                .withFilterFactory(sendOfflineStorageHandler);
+        onFailedSendChainFactory = new RaygunOnFailedSendChainFactory();
     }
 
     public IRaygunClientFactory withApiKey(String apiKey) {
@@ -94,7 +91,7 @@ public class RaygunServletClientFactory implements IRaygunServletClientFactory {
     }
 
     public IRaygunServletClientFactory withOfflineStorage(String storageDir) {
-        RaygunOnFailedSendOfflineStorageHandler sendOfflineStorageHandler = new RaygunOnFailedSendOfflineStorageHandler(storageDir);
+        RaygunOnFailedSendOfflineStorageHandler sendOfflineStorageHandler = new RaygunOnFailedSendOfflineStorageHandler(storageDir, apiKey);
 
         onBeforeSendChainFactory.withFilterFactory(sendOfflineStorageHandler);
         onFailedSendChainFactory.withFilterFactory(sendOfflineStorageHandler);

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
@@ -73,9 +73,9 @@ public class RaygunServletClientFactoryTest {
 
         IRaygunServletClientFactory factory = new RaygunServletClientFactory("apiKey").withBeforeSend(onBeforeSendhandlerFactory);
 
-        assertEquals(factory.getRaygunOnBeforeSendChainFactory().getHandlersFactory().get(1), onBeforeSendhandlerFactory);
+        assertEquals(factory.getRaygunOnBeforeSendChainFactory().getHandlersFactory().get(0), onBeforeSendhandlerFactory);
 
-        assertEquals(((RaygunOnBeforeSendChain)factory.newClient(null).getOnBeforeSend()).getHandlers().get(1), handler);
+        assertEquals(((RaygunOnBeforeSendChain)factory.newClient(null).getOnBeforeSend()).getHandlers().get(0), handler);
     }
 
     @Test

--- a/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
+++ b/webprovider/src/test/java/com/mindscapehq/raygun4java/webprovider/RaygunServletClientFactoryTest.java
@@ -1,12 +1,15 @@
 package com.mindscapehq.raygun4java.webprovider;
 
+import com.mindscapehq.raygun4java.core.IRaygunClientFactory;
 import com.mindscapehq.raygun4java.core.IRaygunOnAfterSend;
 import com.mindscapehq.raygun4java.core.IRaygunOnBeforeSend;
 import com.mindscapehq.raygun4java.core.IRaygunSendEventFactory;
 import com.mindscapehq.raygun4java.core.RaygunClient;
+import com.mindscapehq.raygun4java.core.RaygunClientFactory;
 import com.mindscapehq.raygun4java.core.RaygunConnection;
 import com.mindscapehq.raygun4java.core.RaygunOnAfterSendChain;
 import com.mindscapehq.raygun4java.core.RaygunOnBeforeSendChain;
+import com.mindscapehq.raygun4java.core.handlers.offlinesupport.RaygunOnFailedSendOfflineStorageHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -70,9 +73,9 @@ public class RaygunServletClientFactoryTest {
 
         IRaygunServletClientFactory factory = new RaygunServletClientFactory("apiKey").withBeforeSend(onBeforeSendhandlerFactory);
 
-        assertEquals(factory.getRaygunOnBeforeSendChainFactory().getHandlersFactory().get(0), onBeforeSendhandlerFactory);
+        assertEquals(factory.getRaygunOnBeforeSendChainFactory().getHandlersFactory().get(1), onBeforeSendhandlerFactory);
 
-        assertEquals(((RaygunOnBeforeSendChain)factory.newClient(null).getOnBeforeSend()).getHandlers().get(0), handler);
+        assertEquals(((RaygunOnBeforeSendChain)factory.newClient(null).getOnBeforeSend()).getHandlers().get(1), handler);
     }
 
     @Test
@@ -124,5 +127,13 @@ public class RaygunServletClientFactoryTest {
         client.send(exception);
 
         verify(raygunConnection, times(1)).getConnection(anyString());
+    }
+
+    @Test
+    public void shouldSetOfflineStorageHandler() {
+        IRaygunClientFactory factory = new RaygunClientFactory("apiKey").withOfflineStorage();
+        assertTrue(factory.getRaygunOnBeforeSendChainFactory().getHandlersFactory().get(0) instanceof RaygunOnFailedSendOfflineStorageHandler);
+
+        assertEquals(factory.getRaygunOnBeforeSendChainFactory().getHandlersFactory().get(0), factory.getRaygunOnFailedSendChainFactory().getHandlersFactory().get(0));
     }
 }


### PR DESCRIPTION
This PR adds support for offline storage when sending fails (non 200/429 response code).

* adds a OnSendFailed handler, chain and factory
* adds optional support for offline storage 
defaults to directory in current working directory or optionally with provided path
only sends offline storage on first error occurring (no startup sending)
offline storage is in plain text and is not secured
offline storage is partitioned by apikey hash to prevent cross key sending
* adds the current client as an argument to the send handlers
