### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 - 1.6.0: Envionemnt log statements now guarded and namespaced under Raygun4java.enironment; upgrade Play to 2.3/support Scala 2.10/2.11
 
-- 1.5.0: Added enhanced user data support with SetUser(RaygunIdentifier) - this deprecates SetUser(string)
+- 1.5.0: Added enhanced user/customer data support with SetUser(RaygunIdentifier) - this deprecates SetUser(string)
 
 - 1.4.2: Added Scala RequestHeader overload in constructor for Play 2 provider (rg4j-play2 is now at 0.4.4)
 
@@ -62,9 +62,9 @@
 
 - 1.2.5: Fix a bug where the package used to populate the environment data was not available in certain runtime environments (OSGi, some JVMs)
 
-- 1.2.4: Refactored webprovider package; added SetUser method for unique user tracking; added authenticated proxy support.
+- 1.2.4: Refactored webprovider package; added SetUser method for unique user tracking/Customers; added authenticated proxy support.
 
-- 1.2.3: Added tags and user custom data method overloads for Send. See usage in the updated Sampleapp class.
+- 1.2.3: Added tags and user/customer custom data method overloads for Send. See usage in the updated Sampleapp class.
 
 - 1.2.1: Breaking change: Completed change from ant to maven for packaging and building. The three parts are now maven modules, core, webprovider and sampleapp. The main provider is now located in the *core* namespace, and the JSP and Servlet module is located in *webprovider*.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Download the JARs for the latest version from here:
 [gson](http://repo1.maven.org/maven2/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar): *required* - you will also need the Gson dependency in your classpath.
 
 ## Basic Usage
-An instance of the `RaygunClient` holds all the data for tracking errors, such as user information, tags etc. Whether you're application is single user desktop application and/or multi-user server application, it is highly recommended to use a single `RaygunClient` per process. For example, in a web context it is essential to use a new `RaygunClient` for each user request.
+An instance of the `RaygunClient` holds all the data for tracking errors, such as customer information, tags etc. Whether you're application is single user desktop application and/or multi-user server application, it is highly recommended to use a single `RaygunClient` per process. For example, in a web context it is essential to use a new `RaygunClient` for each user request.
 
 The most basic usage of Raygun is as follows:
 1. Setup `RaygunClient` with configuration options
@@ -133,7 +133,7 @@ public class MyErrorTracker {
     }
 
     /**
-     * Custom method to set our user
+     * Custom method to set our customer
      * @param user
      */
     public void setUser(User user) {
@@ -335,9 +335,9 @@ def index = Action { implicit request =>
 
 ## Documentation
 
-### Affected user tracking
+### Affected Customers
 
-You can call `client.setUser(RaygunIdentifier)` to set the current user's data, which will be displayed in the dashboard. There are two constructor overloads available, both of which requires a unique string as the `uniqueUserIdentifier`. This could be the user's email address if available, or an internally unique ID representing the users. Any errors containing this string will be considered to come from that user.
+You can call `client.setUser(RaygunIdentifier)` to set the current customer's data, which will be displayed in the dashboard. There are two constructor overloads available, both of which requires a unique string as the `uniqueUserIdentifier`. This could be the customer's email address if available, or an internally unique ID representing the customers. Any errors containing this string will be considered to come from that customer.
 
 The other overload contains all the available properties, some or all of which can be null and can be also be set individually on the `RaygunIdentifier` object.
 


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' within documentation 👤

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code need to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG` document

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'Users' or 'User tracking'

### Checklist ✔️ 
- [ ] Builds pass
- [ ] Reviewed by another developer
- [ ] Code is written to standards